### PR TITLE
CI: 라이브러리 캐싱

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,27 +1,16 @@
-# This is a basic workflow to help you get started with Actions
 name: node.js CI
-
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   pull_request:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  job-install-dependencies:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: ["14", "16"] # 테스트할 노드 환경
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
       # Runs a single command using the runners shell
@@ -29,25 +18,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
       # node module 캐싱
       - name: Cache node modules
-        id: cache-npm
         uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
+        id: cache-npm
         with:
-          # npm 캐시 파일 경로
-          path: ~/.npm
-          # 캐시를 저장할때 생성되는 키
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.npm # npm 캐시 파일 경로
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }} # 캐시를 저장할때 생성되는 키
           # key로 못찾았다면 찾는 대체키
           restore-keys: |
             ${{ runner.os }}-node-modules-
-
       # 라이브러리 설치. 일치하는 키가 없다면 설치
       - name: Install Dependencies
-        if: ${{ steps.cache-npm.outputs.cache-hit == 'false' }}
+        if: steps.cache-npm.outputs.cache-hit == 'false'
         run: npm install
 
       # 테스트 실행


### PR DESCRIPTION
##  CI 라이브러리 캐싱
- CI 때 매번 라이브러리들을 재설치하지 않고 캐싱 처리하기

<img width="670" alt="스크린샷 2022-06-24 오후 5 43 21" src="https://user-images.githubusercontent.com/105474635/175498715-648d2353-cee9-48d6-a3a1-38a63eb6602a.png">

- 키를 못찾는 문제 -> 덕분에 라이브러리가 설치가 안되어 jest 명령어도 찾을 수 없음