### PR TITLE
CI: node 14 제거

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ["14", "16"]
+        node-version: ["16"]
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v3


### PR DESCRIPTION
- 개발, 배포 환경 모두 16만 사용하므로 14 버전은 제거함