### PR TITLE
Chore: Dockerfile RUN npm ci로 수정

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ WORKDIR /backend/
 
 COPY package*.json /backend/
 
-RUN npm install
+RUN npm ci
 
 COPY . /backend/
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -4,7 +4,7 @@ WORKDIR /backend/
 
 COPY package*.json /backend/
 
-RUN npm install
+RUN npm ci
 
 COPY . /backend/
 


### PR DESCRIPTION
## 작업사항
- 라이브러리의 버전별 차이로 인한 에러를 일으킬 수 있으므로 ci로 수정함
## 변경로직

### 변경전
```
RUN npm install
```
### 변경후
```
RUN npm ci
```
## 기타

참고링크
https://docs.npmjs.com/cli/v8/commands/npm-ci
https://medium.com/@trustyoo86/ci-%ED%99%98%EA%B2%BD%EC%9D%84-%EC%9C%84%ED%95%9C-npm-ci-npm-ci-for-continous-integration-850fc48dd4cc

> 이 명령은 테스트 플랫폼, 지속적 통합 및 배포와 같은 자동화된 환경 또는 종속성을 새로 설치하려는 모든 상황에서 사용한다는 점을 제외하면 npm install과 유사합니다. npm install과 npm ci 사용의 주요 차이점은 다음과 같습니다. 프로젝트에 기존 package-lock.json 또는 npm-shrinkwrap.json이 있어야 합니다. 패키지 잠금의 종속성이 package.json의 종속성과 일치하지 않으면 npm ci는 패키지 잠금을 업데이트하는 대신 오류와 함께 종료됩니다. npm ci는 한 번에 전체 프로젝트만 설치할 수 있습니다. 이 명령으로 개별 종속성을 추가할 수 없습니다. node_modules가 이미 있는 경우 npm ci가 설치를 시작하기 전에 자동으로 제거됩니다. package.json이나 어떤 package-lock에도 쓰지 않을 것입니다: 설치는 본질적으로 동결됩니다. 참고: --legacy-peer-deps 또는 --install-links와 같이 종속성 트리의 모양에 영향을 줄 수 있는 플래그와 함께 npm install을 실행하여 package-lock.json 파일을 생성하는 경우 동일한 플래그를 제공해야 합니다. npm ci로 변경하지 않으면 오류가 발생할 수 있습니다. 이를 수행하는 쉬운 방법은 예를 들어 npm config set legacy-peer-deps=true --location=project를 실행하고 .npmrc 파일을 저장소에 커밋하는 것입니다.

> npm install 커맨드는 package.json내의 dependencies와 devDependencies를 기준으로 패키지 파일을 설치하게 되어 있습니다. 이에 반해, npm ci는 package.json보다 package-lock.json이 우선합니다. package-lock.json 등의 lockfile을 기준으로 package를 설치하게 되어 있으므로, 규모가 큰 조직에서 package에 대한 lockfile이 승인되면, npm ci를 활용하여 package-lock.json에 명시되어 있는 패키지를 설치하도록 합니다.
