### PR TITLE
Chore: .dockerignore 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# 의존성 디렉토리
+node_modules
+
+# 로그
+logs
+*.log
+
+# 문서
+docs


### PR DESCRIPTION
## 개요
도커 이미지 빌드시 로그 등 불필요 파일도 같이 빌드하는 상황
## 작업사항
`.dockerignore` 추가하여
* 불필요 파일 이미지에 빌드안하기
* Docker 이미지에 로컬 모듈과 디버깅 로그를 복사하는 것을 막아서 이미지 내에서 설치한 모듈을 덮어쓰지 않게 함

## 기타
참고
https://nodejs.org/ko/docs/guides/nodejs-docker-webapp/#dockerignore