### PR TITLE
Update: 대댓글 작성 taggedId NOT NULL로 수정, 로직 개선

### DIFF
--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -82,7 +82,7 @@ export class CommentService implements ICommentService {
     user: User,
     postId: number,
     parentId: number,
-    taggedId: number | undefined,
+    taggedId: number,
     content: string,
     isSecret: boolean
   ): Promise<ReplyResponseDto> {

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -98,9 +98,7 @@ export class CommentService implements ICommentService {
       if (!replyTarget || !replyTarget.isActive)
         throw new NotFoundException(`not exists comment`);
       if (replyTarget.isReply())
-        throw new BadReqeustException(
-          `replies cannot be written to a reply with a parent id` //TODO: 응답메세지 수정
-        );
+        throw new BadReqeustException(`invalid parent comment id`);
     }
     // parentId !== taggedId라면 대댓글에 대한 대댓글 작성이다.
     else {

--- a/src/modules/comment/dto/create-reply.dto.ts
+++ b/src/modules/comment/dto/create-reply.dto.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, IsOptional, Min } from "class-validator";
+import { IsInt, IsNotEmpty, Min } from "class-validator";
 import { CreateCommentDto } from "./create-comment.dto";
 
 export class CreateReplyDto extends CreateCommentDto {
@@ -9,6 +9,6 @@ export class CreateReplyDto extends CreateCommentDto {
 
   @IsInt()
   @Min(1)
-  @IsOptional()
-  taggedId?: number;
+  @IsNotEmpty()
+  taggedId: number;
 }

--- a/src/modules/comment/entity/comment.entity.ts
+++ b/src/modules/comment/entity/comment.entity.ts
@@ -71,11 +71,11 @@ export class Comment extends BaseEntity {
     content: string,
     isSecret: boolean,
     parentId: number,
-    taggedId?: number
+    taggedId: number
   ) {
     const reply = Comment.of(post, user, content, isSecret);
-    reply.parentId = parentId ?? undefined;
-    reply.taggedId = taggedId ?? undefined;
+    reply.parentId = parentId;
+    reply.taggedId = taggedId;
     return reply;
   }
 }

--- a/src/modules/comment/entity/comment.entity.ts
+++ b/src/modules/comment/entity/comment.entity.ts
@@ -78,4 +78,13 @@ export class Comment extends BaseEntity {
     reply.taggedId = taggedId;
     return reply;
   }
+
+  /**
+   * comment entity가 대댓글인지 확인하는 메서드
+   */
+  isReply() {
+    // parentId 값이 있다면, 대댓글
+    if (!this.parentId) return true;
+    return false;
+  }
 }

--- a/src/modules/comment/entity/comment.entity.ts
+++ b/src/modules/comment/entity/comment.entity.ts
@@ -84,7 +84,7 @@ export class Comment extends BaseEntity {
    */
   isReply() {
     // parentId 값이 있다면, 대댓글
-    if (!this.parentId) return true;
+    if (this.parentId) return true;
     return false;
   }
 }

--- a/src/modules/comment/interfaces/IComment.repository.ts
+++ b/src/modules/comment/interfaces/IComment.repository.ts
@@ -1,5 +1,4 @@
-import { GetAllCommentDto } from "../dto/get-all-comment.dto";
-import { GetAllRepliesDto } from "../dto/get-all-replies.dto";
+import { GetAllCommentDto, GetAllRepliesDto } from "../dto";
 import { Comment } from "../entity/comment.entity";
 
 export interface ICommentRepository {

--- a/src/modules/comment/interfaces/IComment.service.ts
+++ b/src/modules/comment/interfaces/IComment.service.ts
@@ -5,7 +5,7 @@ import {
   PageInfoDto,
   PageResponseDto,
 } from "../../../shared/page";
-import { GetAllRepliesDto } from "../dto/get-all-replies.dto";
+import { GetAllRepliesDto } from "../dto";
 
 export interface ICommentService {
   createComment(

--- a/src/swagger/paths/comments/replies.yaml
+++ b/src/swagger/paths/comments/replies.yaml
@@ -1,7 +1,7 @@
 post:
   tags:
     - comments
-  description: 대댓글 등록
+  description: 부모 댓글(parentId)에 속하는 댓글(taggedId)에 대해 대댓글을 등록합니다. <br /> parentId와 taggedId가 같은 값이면 댓글에 대한 대댓글을 등록합니다.  <br />두 값이 다르다면 대댓글에 대한 대댓글을 등록합니다.
   requestBody:
     content:
       application/json:

--- a/src/swagger/responses/comments/replies.post.yaml
+++ b/src/swagger/responses/comments/replies.post.yaml
@@ -49,7 +49,7 @@
             example: 12
 
 "400":
-  description: 대댓글에 대댓글 작성 시도함 or 태그된 댓글이 같은 댓글그룹이 아님
+  description: 태그된 댓글이 같은 댓글그룹이 아님 || parent id가 부모 댓글이 아닌 대댓글임
   content:
     application/json:
       schema:
@@ -57,7 +57,7 @@
         properties:
           message:
             type: string
-            example: replies cannot be written to a reply with a parent id || tagged comments must be in the same comment group
+            example: tagged reply must be in the same comment group || invalid parent comment id
 
 "401":
   description: access token 유효하지 않음
@@ -71,7 +71,7 @@
             example: authentication error
 
 "404":
-  description: 존재하지 않는 (삭제된) 게시글 | 댓글
+  description: 존재하지 않는 (삭제된) 게시글 | 댓글 | 대댓글
   content:
     application/json:
       schema:
@@ -79,4 +79,4 @@
         properties:
           message:
             type: string
-            example: not exists post
+            example: not exists post || not exists comment || not exists reply


### PR DESCRIPTION
## 개요
대댓글 작성 API의 알림 기능 추가전 다음 내용들의 수정이 필요했습니다.
- 대댓글 대상 `taggedId` not null로 수정하기
- CommentService.createReply 로직 개선하기

## 작업사항
### 1. [Update: 대댓글 taggedId notnull 로 수정](https://github.com/MBTI-Channel/server/commit/241a104c27517095aa09670e02b0b2eb869ee9e7)


이전에 @FaberJoo님과 대댓글 작성 로직 회의에서 내용은 
```
parentId - 부모댓글
taggedId - 태그할 댓글 대상 null 가능
```
- `taggedId`를 null로 요청할 경우, 부모 댓글에 대한 대댓글이고
- `taggedId`가 notnull로 요청할 경우, 대댓글에 대한 대댓글 작성이었는데요.

이는 `taggedId` `parentId`를 동일하게 요청하면 안되는데, 예외사항이 하나 더 추가되어서 다음과 같이 수정했습니다.
```
parentId - 부모댓글
taggedId - 태그할 댓글 대상 null 안됨
```

### 2. [Add: comment entity isReply 메서드](https://github.com/MBTI-Channel/server/commit/1d6cf1279cfa2c6048857203e75f5e16ac37024a)

```ts
// parentId === taggedId라면 부모 댓글에 대한 대댓글 작성이다.
if (parentId === taggedId) {
...
if(taggedTarget.parentId) throw new BadReqeustException(`invalid parent comment id`);
```
이 방법보다
```ts
// parentId === taggedId라면 부모 댓글에 대한 대댓글 작성이다.
if (parentId === taggedId) {
...
if(taggedTarget.isReply()) throw new BadReqeustException(`invalid parent comment id`);
```
"아  대댓글 대상인 `taggedTarget`이 부모 댓글이라면,  대댓글(reply)이면 안되는구나"가 명확해보여서 추가했습니다.
## 변경로직
[Refactor: 대댓글 작성 api - 부모 댓글을 대댓글로 요청시 에러 메세지 수정](https://github.com/MBTI-Channel/server/commit/4e1cc1017d7ba8a1b416f2e609f2f6d70acd3787)
### 변경전
1. postId가 존재하는 post인지
2. parentId가 존재하는 comment인지 + 부모댓글이 맞는지
3. taggedId가 존재하는 comment인지 + 같은 댓글 군에 속하는지
```ts
    // 대댓글 작성할 게시글이 존재하는지 확인
    const post = await this._postRepository.findOneById(postId);
    if (!post || !post.isActive) throw new NotFoundException(`not exists post`);
    // 부모 댓글이 존재하는지 확인
    const parentComment = await this._commentRepository.findOneById(parentId);
    if (!parentComment || !parentComment.isActive)
      throw new NotFoundException(`not exists comment`);
    // 부모댓글이 부모댓글이 맞는지 확인
    if (parentComment.parentId)
      throw new BadReqeustException(
        `replies cannot be written to a reply with a parent id`
      );

    // 태그된 댓글 검증
    if (taggedId) {
      const taggedReply = await this._commentRepository.findOneById(taggedId);
      if (!taggedReply || !taggedReply.isActive)
        throw new NotFoundException(`not exists comment`);
      // 태그된 댓글이 같은 댓글군에 포함되는지 확인
      if (taggedReply.parentId !== parentId)
        throw new BadReqeustException(
          `tagged comments must be in the same comment group`
        );
    }
```
### 변경후
- `findOneById` 메서드 3회에서 2회로 감소 -> 쿼리 요청 1회 감소
- 1 postId가 존재하는 post인지
- 2.1 parentId가 존재하는 comment인지 + 부모댓글이 맞는지
- 2.2 taggedId가 존재하는 comment인지 + 같은 댓글 군에 속하는지
```ts
    let replyTarget: Comment | null;

    // 대댓글 작성할 게시글이 존재하는지 확인
    const post = await this._postRepository.findOneById(postId);
    if (!post || !post.isActive) throw new NotFoundException(`not exists post`);

    // parentId === taggedId라면 부모 댓글에 대한 대댓글 작성이다.
    if (parentId === taggedId) {
      replyTarget = await this._commentRepository.findOneById(parentId);
      if (!replyTarget || !replyTarget.isActive)
        throw new NotFoundException(`not exists comment`);
      if (replyTarget.isReply())
        throw new BadReqeustException(`invalid parent comment id`);
    }
    // parentId !== taggedId라면 대댓글에 대한 대댓글 작성이다.
    else {
      replyTarget = await this._commentRepository.findOneById(taggedId);
      if (!replyTarget || !replyTarget.isActive)
        throw new NotFoundException(`not exists reply`);
      // 대댓글이 같은 댓글군에 포함되는지 확인
      if (replyTarget.parentId !== parentId)
        throw new BadReqeustException(
          `tagged reply must be in the same comment group`
        );
    }
```

## 기타

- 예외 응답 메세지를 수정했습니다.
- swagger에도 반영했고 대댓글 작성 설명도 taggedId, parentId에 대해 명확하게 설명을 추가했습니다.

여기에 알림 추가할 예정이에요 🙂