### PR TITLE
Feat: delete like API

### DIFF
--- a/src/modules/comment/comment.repository.ts
+++ b/src/modules/comment/comment.repository.ts
@@ -107,6 +107,13 @@ export class CommentRepository implements ICommentRepository {
     return false;
   }
 
+  public async decreaseLikeCount(id: number): Promise<boolean> {
+    const repository = await this._database.getRepository(Comment);
+    const result = await repository.decrement({ id }, "likesCount", 1);
+    if (result.affected === 1) return true;
+    return false;
+  }
+
   async remove(id: number): Promise<void> {
     const repository = await this._database.getRepository(Comment);
     await repository.update(id, {

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -228,6 +228,18 @@ export class CommentService implements ICommentService {
     if (!hasIncreased) throw new NotFoundException(`not exists comment`);
   }
 
+  async decreaseLikeCount(id: number): Promise<void> {
+    this._logger.trace(`[CommentService] decreaseLikeCount start`);
+    // 댓글이 존재하는지 확인
+    const comment = await this._commentRepository.findOneById(id);
+    if (!comment || !comment.isActive)
+      throw new NotFoundException(`not exists comment`);
+
+    // 댓글 좋아요 수 감소. 만약 도중에 삭제되었다면 false 반환
+    const hasIncreased = await this._commentRepository.decreaseLikeCount(id);
+    if (!hasIncreased) throw new NotFoundException(`not exists comment`);
+  }
+
   async update(user: User, id: number, content: string) {
     // 댓글 존재하는지 확인
     const comment = await this._commentRepository.findOneById(id);

--- a/src/modules/comment/interfaces/IComment.repository.ts
+++ b/src/modules/comment/interfaces/IComment.repository.ts
@@ -13,5 +13,6 @@ export interface ICommentRepository {
   update(id: number, content: Partial<Comment>): Promise<Comment>;
   increaseReplyCount(id: number): Promise<boolean>;
   increaseLikeCount(id: number): Promise<boolean>;
+  decreaseLikeCount(id: number): Promise<boolean>;
   remove(id: number): Promise<void>;
 }

--- a/src/modules/comment/interfaces/IComment.service.ts
+++ b/src/modules/comment/interfaces/IComment.service.ts
@@ -31,6 +31,7 @@ export interface ICommentService {
     user: User
   ): Promise<PageResponseDto<PageInfiniteScrollInfoDto, ReplyResponseDto>>;
   increaseLikeCount(id: number): Promise<void>;
+  decreaseLikeCount(id: number): Promise<void>;
   update(user: User, id: number, content: string): Promise<CommentResponseDto>;
   delete(user: User, id: number): Promise<void>;
 }

--- a/src/modules/like/dto/delete-like.dto.ts
+++ b/src/modules/like/dto/delete-like.dto.ts
@@ -1,0 +1,15 @@
+import { Type } from "class-transformer";
+import { IsEnum, IsInt, IsNotEmpty, Min } from "class-validator";
+import { LikeTargetType } from "../../../shared/enum.shared";
+
+export class DeleteLikeDto {
+  @IsEnum(LikeTargetType)
+  @IsNotEmpty()
+  type: string;
+
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  @IsNotEmpty()
+  targetId: number;
+}

--- a/src/modules/like/interfaces/ILike.repository.ts
+++ b/src/modules/like/interfaces/ILike.repository.ts
@@ -2,6 +2,11 @@ import { Like } from "../entity/like.entity";
 
 export interface ILikeRepository {
   findOneById(id: number): Promise<Like | null>;
-  findOneByTarget(targetId: number, targetType: number): Promise<Like | null>;
+  findOneByTarget(
+    userId: number,
+    targetId: number,
+    targetType: number
+  ): Promise<Like | null>;
   createLike(likeEntity: Like): Promise<Like>;
+  remove(id: number): Promise<void>;
 }

--- a/src/modules/like/interfaces/ILike.repository.ts
+++ b/src/modules/like/interfaces/ILike.repository.ts
@@ -9,4 +9,5 @@ export interface ILikeRepository {
   ): Promise<Like | null>;
   createLike(likeEntity: Like): Promise<Like>;
   remove(id: number): Promise<void>;
+  active(id: number): Promise<Like>;
 }

--- a/src/modules/like/interfaces/ILike.service.ts
+++ b/src/modules/like/interfaces/ILike.service.ts
@@ -8,5 +8,5 @@ export interface ILikeService {
     user: User
   ): Promise<LikeResponseDto>;
   //   getStatus(type: number, targetId: number, user: User): Promise<boolean>;
-  //   delete(type: number, targetId: number, user: User): Promise<void>;
+  deleteLike(type: string, targetId: number, user: User): Promise<void>;
 }

--- a/src/modules/like/like.controller.ts
+++ b/src/modules/like/like.controller.ts
@@ -1,10 +1,20 @@
 import { Request, Response } from "express";
 import { inject } from "inversify";
-import { controller, httpPost, requestBody } from "inversify-express-utils";
+import {
+  controller,
+  httpDelete,
+  httpPost,
+  queryParam,
+  requestBody,
+} from "inversify-express-utils";
 import { TYPES } from "../../core/types.core";
-import { bodyValidator } from "../../middlewares/validator.middleware";
+import {
+  bodyValidator,
+  queryValidator,
+} from "../../middlewares/validator.middleware";
 import { User } from "../user/entity/user.entity";
 import { CreateLikeDto } from "./dto/create-like.dto";
+import { DeleteLikeDto } from "./dto/delete-like.dto";
 import { ILikeService } from "./interfaces/ILike.service";
 
 @controller("/likes")
@@ -28,5 +38,24 @@ export class LikeController {
     const data = await this._likeService.createLike(type, targetId, user);
 
     return res.status(201).json(data);
+  }
+
+  // 좋아요 삭제
+  @httpDelete(
+    "/",
+    TYPES.ValidateAccessTokenMiddleware,
+    queryValidator(DeleteLikeDto)
+  )
+  async deleteLike(
+    @queryParam() query: DeleteLikeDto,
+    req: Request,
+    res: Response
+  ) {
+    const { type, targetId } = query;
+    const user = req.user as User;
+
+    await this._likeService.deleteLike(type, targetId, user);
+
+    return res.status(204).json();
   }
 }

--- a/src/modules/like/like.repository.ts
+++ b/src/modules/like/like.repository.ts
@@ -3,6 +3,7 @@ import { TYPES } from "../../core/types.core";
 import { IDatabaseService } from "../../core/database/interfaces/IDatabase.service";
 import { Like } from "./entity/like.entity";
 import { ILikeRepository } from "./interfaces/ILike.repository";
+import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 
 @injectable()
 export class LikeRepository implements ILikeRepository {
@@ -16,16 +17,26 @@ export class LikeRepository implements ILikeRepository {
   }
 
   async findOneByTarget(
+    userId: number,
     targetId: number,
     targetType: number
   ): Promise<Like | null> {
     const repository = await this._database.getRepository(Like);
-    return await repository.findOne({ where: { targetId, targetType } });
+    return await repository.findOne({
+      where: { userId, targetId, targetType },
+    });
   }
 
   async createLike(likeEntity: Like): Promise<Like> {
     const repository = await this._database.getRepository(Like);
     const like = await repository.save(likeEntity);
     return like;
+  }
+
+  async remove(id: number): Promise<void> {
+    const repository = await this._database.getRepository(Like);
+    await repository.update(id, {
+      isActive: false,
+    } as QueryDeepPartialEntity<Like>);
   }
 }

--- a/src/modules/like/like.repository.ts
+++ b/src/modules/like/like.repository.ts
@@ -39,4 +39,14 @@ export class LikeRepository implements ILikeRepository {
       isActive: false,
     } as QueryDeepPartialEntity<Like>);
   }
+
+  async active(id: number): Promise<Like> {
+    const repository = await this._database.getRepository(Like);
+    const like = await repository
+      .update(id, {
+        isActive: true,
+      } as QueryDeepPartialEntity<Like>)
+      .then(async () => await repository.findOne({ where: { id } }));
+    return like;
+  }
 }

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -4,6 +4,7 @@ import { IDatabaseService } from "../../core/database/interfaces/IDatabase.servi
 import { LikeTargetType } from "../../shared/enum.shared";
 import {
   BadReqeustException,
+  ForbiddenException,
   NotFoundException,
 } from "../../shared/errors/all.exception";
 import { HttpException } from "../../shared/errors/http.exception";
@@ -17,6 +18,8 @@ import { LikeResponseDto } from "./dto/like-response.dto";
 import { Like } from "./entity/like.entity";
 import { ILikeRepository } from "./interfaces/ILike.repository";
 import { ILikeService } from "./interfaces/ILike.service";
+import { Post } from "../post/entity/post.entity";
+import { Comment } from "../comment/entity/comment.entity";
 
 @injectable()
 export class LikeService implements ILikeService {
@@ -34,22 +37,51 @@ export class LikeService implements ILikeService {
     @inject(TYPES.IDatabaseService)
     private readonly _dbService: IDatabaseService
   ) {}
-  async createLike(
+
+  private async _checkMbti(target: Post | Comment, user: User, type: string) {
+    let aver_target;
+    if (type === LikeTargetType.POST) {
+      aver_target = target as Post;
+      if (
+        aver_target.type === Post.typeTo("mbti") &&
+        user.mbti !== aver_target.userMbti
+      )
+        throw new ForbiddenException("authorization error");
+    }
+
+    if (type === LikeTargetType.COMMENT) {
+      aver_target = target as Comment;
+      const post = await this._postRepository.findOneById(aver_target.postId);
+      if (!post || !post.isActive)
+        throw new NotFoundException(`not exists target`);
+      if (post.type === Post.typeTo("mbti") && user.mbti !== post?.userMbti)
+        throw new ForbiddenException("authorization error");
+    }
+  }
+
+  private async _checkId(type: string, targetId: number) {
+    let target;
+
+    if (type === LikeTargetType.POST)
+      target = await this._postRepository.findOneById(targetId);
+    if (type === LikeTargetType.COMMENT)
+      target = await this._commentRepository.findOneById(targetId);
+
+    if (!target || !target.isActive)
+      throw new NotFoundException(`not exists target`);
+
+    return target;
+  }
+
+  public async createLike(
     type: string,
     targetId: number,
     user: User
   ): Promise<LikeResponseDto> {
     this._logger.trace(`[LikeService] createLike start`);
 
-    // targetId 존재 여부
-    let target;
-    if (type === LikeTargetType.POST) {
-      target = await this._postRepository.findOneById(targetId);
-    } else if (type === LikeTargetType.COMMENT) {
-      target = await this._commentRepository.findOneById(targetId);
-    }
-    if (!target || !target.isActive)
-      throw new NotFoundException(`not exists target`);
+    // targetId 존재하는지 확인
+    let target = await this._checkId(type, targetId);
 
     // post: 1 , comment: 2
     const targetType = type === LikeTargetType.POST ? 1 : 2;
@@ -63,27 +95,20 @@ export class LikeService implements ILikeService {
       throw new BadReqeustException(`like already existed`);
     }
 
-    // TODO: MBTI check
-    // if (type === LikeTargetType.POST) {
-    //   if (target.type === Post.typeTo("mbti") && user.mbti !== target.userMbti)
-    //     throw new ForbiddenException("authorization error");
-    // } else if (type === LikeTargetType.COMMENT){
-    //   const post = await this._postRepository.findOneById(target.postId);
-    //   if (post.type === Post.typeTo("mbti") && user.mbti !== post.userMbti)
-    //     throw new ForbiddenException("authorization error")
-    // }
+    // mbti 게시글일 경우 mbti 확인
+    await this._checkMbti(target, user, type);
 
     const likeEntity = Like.of(target, user, targetType);
-
     const t = await this._dbService.getTransaction();
     await t.startTransaction();
     try {
       const like = await this._likeRepository.createLike(likeEntity);
-      if (type === LikeTargetType.POST) {
+      if (type === LikeTargetType.POST)
         await this._postService.increaseLikeCount(targetId);
-      } else if (type === LikeTargetType.COMMENT) {
+
+      if (type === LikeTargetType.COMMENT)
         await this._commentService.increaseLikeCount(targetId);
-      }
+
       // TODO: notification check
       await t.commitTransaction();
       return new LikeResponseDto(target, like);
@@ -94,4 +119,6 @@ export class LikeService implements ILikeService {
       await t.release();
     }
   }
+
+  async deleteLike(type: string, targetId: number, user: User): Promise<void> {}
 }

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -57,14 +57,14 @@ export class LikeService implements ILikeService {
       aver_target = target as Comment;
       const post = await this._postRepository.findOneById(aver_target.postId);
       if (!post || !post.isActive)
-        throw new NotFoundException(`not exists target`);
+        throw new NotFoundException(`not exists post`);
       if (post.type === Post.typeTo("mbti") && user.mbti !== post?.userMbti)
         throw new ForbiddenException("authorization error");
     }
   }
 
   private async _checkId(type: string, targetId: number) {
-    let target;
+    let target: Post | Comment | null = null;
 
     if (type === LikeTargetType.POST)
       target = await this._postRepository.findOneById(targetId);

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -131,5 +131,41 @@ export class LikeService implements ILikeService {
     }
   }
 
-  async deleteLike(type: string, targetId: number, user: User): Promise<void> {}
+  async deleteLike(type: string, targetId: number, user: User): Promise<void> {
+    this._logger.trace(`[LikeService] deleteLike start`);
+
+    // targetId 존재하는지 확인
+    let target = await this._checkId(type, targetId);
+    // post: 1 , comment: 2
+    const targetType = type === LikeTargetType.POST ? 1 : 2;
+    // 이미 좋아요 취소 되어 있는지 확인
+    const foundLike = await this._likeRepository.findOneByTarget(
+      user.id,
+      targetId,
+      targetType
+    );
+    if (!foundLike || !foundLike.isActive) {
+      throw new BadReqeustException(`like already canceld`);
+    }
+
+    // mbti 게시글일 경우 mbti 확인
+    await this._checkMbti(target, user, type);
+
+    const t = await this._dbService.getTransaction();
+    await t.startTransaction();
+    try {
+      await this._likeRepository.remove(foundLike.id);
+      if (type === LikeTargetType.POST)
+        await this._postService.decreaseLikeCount(targetId);
+
+      if (type === LikeTargetType.COMMENT)
+        await this._commentService.decreaseLikeCount(targetId);
+      await t.commitTransaction();
+    } catch (err: any) {
+      await t.rollbackTransaction();
+      throw new HttpException(err.name, err.message, err.status);
+    } finally {
+      await t.release();
+    }
+  }
 }

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -20,6 +20,7 @@ import { ILikeRepository } from "./interfaces/ILike.repository";
 import { ILikeService } from "./interfaces/ILike.service";
 import { Post } from "../post/entity/post.entity";
 import { Comment } from "../comment/entity/comment.entity";
+import { INotificationService } from "../notifications/interfaces/INotification.service";
 
 @injectable()
 export class LikeService implements ILikeService {
@@ -30,6 +31,8 @@ export class LikeService implements ILikeService {
     private readonly _postRepository: IPostRepository,
     @inject(TYPES.ICommentService)
     private readonly _commentService: ICommentService,
+    @inject(TYPES.INotificationService)
+    private readonly _notificationService: INotificationService,
     @inject(TYPES.ICommentRepository)
     private readonly _commentRepository: ICommentRepository,
     @inject(TYPES.ILikeRepository)
@@ -110,6 +113,14 @@ export class LikeService implements ILikeService {
         await this._commentService.increaseLikeCount(targetId);
 
       // TODO: notification check
+      if (!user.isMy(target)) {
+        await this._notificationService.createByTargetUser(
+          user,
+          target.userId,
+          target.id,
+          "likes"
+        );
+      }
       await t.commitTransaction();
       return new LikeResponseDto(target, like);
     } catch (err: any) {

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -91,6 +91,7 @@ export class LikeService implements ILikeService {
 
     // 이미 좋아요 되어 있는지 확인
     const foundLike = await this._likeRepository.findOneByTarget(
+      user.id,
       targetId,
       targetType
     );
@@ -112,7 +113,6 @@ export class LikeService implements ILikeService {
       if (type === LikeTargetType.COMMENT)
         await this._commentService.increaseLikeCount(targetId);
 
-      // TODO: notification check
       if (!user.isMy(target)) {
         await this._notificationService.createByTargetUser(
           user,

--- a/src/modules/post/interfaces/IPost.repository.ts
+++ b/src/modules/post/interfaces/IPost.repository.ts
@@ -7,6 +7,7 @@ export interface IPostRepository {
   findOneById(id: number): Promise<Post | null>;
   increaseCommentCount(id: number): Promise<boolean>;
   increaseLikeCount(id: number): Promise<boolean>;
+  decreaseLikeCount(id: number): Promise<boolean>;
   remove(id: number): Promise<void>;
   findAllPosts(
     pageOptionsDto: GetAllPostDto,

--- a/src/modules/post/interfaces/IPost.service.ts
+++ b/src/modules/post/interfaces/IPost.service.ts
@@ -17,6 +17,7 @@ export interface IPostService {
   ): Promise<PostResponseDto>;
   increaseCommentCount(id: number): Promise<void>;
   increaseLikeCount(id: number): Promise<void>;
+  decreaseLikeCount(id: number): Promise<void>;
   delete(user: User, id: number): Promise<void>;
   getDetail(user: User, id: number): Promise<PostResponseDto>;
   isValid(id: number): Promise<boolean>;

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -41,6 +41,13 @@ export class PostRepository implements IPostRepository {
     return false;
   }
 
+  public async decreaseLikeCount(id: number): Promise<boolean> {
+    const repository = await this._database.getRepository(Post);
+    const result = await repository.decrement({ id }, "likesCount", 1);
+    if (result.affected === 1) return true;
+    return false;
+  }
+
   public async remove(id: number): Promise<void> {
     const repository = await this._database.getRepository(Post);
     await repository.update(id, {

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -82,6 +82,17 @@ export class PostService implements IPostService {
     if (!hasIncreased) throw new NotFoundException(`not exists post`);
   }
 
+  public async decreaseLikeCount(id: number): Promise<void> {
+    this._logger.trace(`[PostService] decreaseLikeCount start`);
+    const post = await this._postRepository.findOneById(id);
+    // err: 존재하지 않는 || 삭제된 게시글 id
+    if (!post || !post.isActive) throw new NotFoundException(`not exists post`);
+
+    const hasIncreased = await this._postRepository.decreaseLikeCount(id);
+    // err: 업데이트 도중 삭제된 게시글 id
+    if (!hasIncreased) throw new NotFoundException(`not exists post`);
+  }
+
   public async delete(user: User, id: number): Promise<void> {
     this._logger.trace(`[PostService] delete start`);
     const post = await this._postRepository.findOneById(id);


### PR DESCRIPTION
## 개요
- 좋아요 삭제 API 개발

## 작업사항
- delete like API 작성
- deleteLikedto 작성
- post, comment 부분에 `decreaseLikeCount` 로직 생성

## 변경로직
- 하나의 함수에서 처리하던 방식에서 함수를 나눠서 진행
 
### 변경전
- createLike 내에서 모든 작업 실행

### 변경후
- `checkId`, `checkMbti` 함수를 만들어 아이디와 mbti 유효성 검사 진행
- `deleteLike` 함수에서 재사용 가능

## 기타