### PR TITLE
Add: 알림 type transformer

### DIFF
--- a/src/modules/notifications/dto/notification-response.dto.ts
+++ b/src/modules/notifications/dto/notification-response.dto.ts
@@ -1,3 +1,4 @@
+import { NotificationType } from "../../../shared/type.shared";
 import { Notification } from "../entity/notification.entity";
 
 export class NotificationResponseDto {
@@ -14,7 +15,7 @@ export class NotificationResponseDto {
     this.id = entity.id;
     this.targetUserId = entity.targetUserId;
     this.targetId = entity.targetId;
-    this.type = Notification.typeFrom(entity.type);
+    this.type = entity.type as NotificationType;
     this.title = entity.title;
     this.url = entity.url;
     this.createdAt = entity.createdAt;

--- a/src/modules/notifications/entity/notification.entity.ts
+++ b/src/modules/notifications/entity/notification.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, Column, ManyToOne } from "typeorm";
+import { NotificationTypeTransformer } from "../helper/notification-type-transformer";
 import { BaseEntity } from "../../../shared/base.entity";
 import { NotificationType } from "../../../shared/type.shared";
-
 import { User } from "../../user/entity/user.entity";
 
 @Entity()
@@ -25,9 +25,10 @@ export class Notification extends BaseEntity {
   @Column({
     nullable: false,
     type: "tinyint",
+    transformer: new NotificationTypeTransformer(),
     comment: "알림 종류[1:comment 2:reply 3:likes 4:trend 5:notice]",
   })
-  type: number;
+  type: number | NotificationType;
 
   @Column({ length: 50, comment: "알림 제목" })
   title: string;
@@ -62,42 +63,10 @@ export class Notification extends BaseEntity {
     notification.userId = type === "notice" ? 1 : userId; // 1:admin
     notification.targetId = targetId;
     notification.url = ""; //TODO: 논의 필요//Notification.setUrlByType(type);
-    notification.type = Notification.typeTo(type);
+    notification.type = type;
     notification.title = Notification.setTitleByType(type, targetUser.nickname);
 
     return notification;
-  }
-
-  // db로 넣을때
-  static typeTo(type: NotificationType) {
-    switch (type) {
-      case "comment":
-        return 1;
-      case "reply":
-        return 2;
-      case "likes":
-        return 3;
-      case "trend":
-        return 4;
-      case "notice":
-        return 5;
-    }
-  }
-
-  // db에서 코드로 바꿀때
-  static typeFrom(type: number) {
-    switch (type) {
-      case 1:
-        return "comment";
-      case 2:
-        return "reply";
-      case 3:
-        return "likes";
-      case 4:
-        return "trend";
-      case 5:
-        return "notice";
-    }
   }
 
   // type에 따른 알림 제목 설정

--- a/src/modules/notifications/helper/notification-type-transformer.ts
+++ b/src/modules/notifications/helper/notification-type-transformer.ts
@@ -1,0 +1,35 @@
+import { ValueTransformer } from "typeorm";
+import { NotificationType } from "../../../shared/type.shared";
+
+export class NotificationTypeTransformer implements ValueTransformer {
+  // entity -> db
+  to(type: NotificationType) {
+    switch (type) {
+      case "comment":
+        return 1;
+      case "reply":
+        return 2;
+      case "likes":
+        return 3;
+      case "trend":
+        return 4;
+      case "notice":
+        return 5;
+    }
+  }
+  // db -> entity
+  from(type: number) {
+    switch (type) {
+      case 1:
+        return "comment";
+      case 2:
+        return "reply";
+      case 3:
+        return "likes";
+      case 4:
+        return "trend";
+      case 5:
+        return "notice";
+    }
+  }
+}


### PR DESCRIPTION
## 개요
Notification의
- type 컬럼 타입 tinyint 
- type 엔티티 타입 string

불일치를 매핑하기 위해 static함수 `typeTo`, `typeFrom`을 사용함
## 작업사항
TypeORM의 ValueTransformer 인터페이스를 구현한 클래스를 만든후,
Column 옵션 중 transformer에 사용함
## 변경로직

### 변경전
```ts
  @Column({
    nullable: false,
    type: "tinyint",
    comment: "알림 종류[1:comment 2:reply 3:likes 4:trend 5:notice]",
  })
  type: number;

// of 메서드
notification.type = Notification.typeTo(type);

// 응답 dto
this.type = Notification.typeFrom(entity.type);
```
### 변경후
- static함수 `typeTo`, `typeFrom` 제거
```
  @Column({
    nullable: false,
    type: "tinyint",
    transformer: new NotificationTypeTransformer(),
    comment: "알림 종류[1:comment 2:reply 3:likes 4:trend 5:notice]",
  })
  type: number | NotificationType;

// of 메서드
notification.type = type

// 응답 dto
this.type = entity.type as NotificationType;
```
## 기타
posts 쪽도 적용이 필요한데 누가할까요??