### PR TITLE
Add: post type transformer

### DIFF
--- a/src/modules/bookmark/bookmark.service.ts
+++ b/src/modules/bookmark/bookmark.service.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from "inversify";
 import { TYPES } from "../../core/types.core";
+import { PostType } from "../../shared/enum.shared";
 import {
   BadReqeustException,
   ForbiddenException,
@@ -44,7 +45,7 @@ export class BookmarkService implements IBookmarkService {
     }
 
     // post type이 mbti일 경우 mbti확인
-    if (post.type === Post.typeTo("mbti") && user.mbti !== post.userMbti) {
+    if (post.type === PostType.MBTI && user.mbti !== post.userMbti) {
       throw new ForbiddenException(`user mbti does not match`);
     }
 

--- a/src/modules/bookmark/dto/bookmark-response.dto.ts
+++ b/src/modules/bookmark/dto/bookmark-response.dto.ts
@@ -1,3 +1,4 @@
+import { PostType } from "../../../shared/enum.shared";
 import { Post } from "../../post/entity/post.entity";
 import { Bookmark } from "../entity/bookmark.entity";
 
@@ -8,7 +9,7 @@ export class BookmarkResponseDto {
   title: string;
   content: string;
   isSecret: boolean;
-  type: string;
+  type: PostType;
   createdAt: Date;
   updatedAt: Date | null;
 
@@ -19,7 +20,7 @@ export class BookmarkResponseDto {
     this.title = post.title;
     this.content = post.content;
     this.isSecret = post.isSecret;
-    this.type = Post.typeFrom(post.type) ?? "";
+    this.type = post.type as PostType;
     this.createdAt = entity.createdAt;
     this.updatedAt =
       entity.createdAt.getTime() === entity.updatedAt.getTime()

--- a/src/modules/post/dto/post-response.dto.ts
+++ b/src/modules/post/dto/post-response.dto.ts
@@ -1,10 +1,11 @@
+import { PostType } from "../../../shared/enum.shared";
 import { User } from "../../user/entity/user.entity";
 import { Post } from "../entity/post.entity";
 
 export class PostResponseDto {
   id: number;
   categoryId: number;
-  type: number;
+  type: PostType;
   isActive: boolean;
   isActiveUser: boolean = true;
   isMy: boolean = false;
@@ -22,7 +23,7 @@ export class PostResponseDto {
   updatedAt: Date | null;
   constructor(post: Post, user: User) {
     this.id = post.id;
-    this.type = post.type;
+    this.type = post.type as PostType;
     this.categoryId = post.categoryId;
     this.isActive = post.isActive;
     this.isActiveUser = user ? user.isActive() : false;

--- a/src/modules/post/entity/post.entity.ts
+++ b/src/modules/post/entity/post.entity.ts
@@ -1,10 +1,12 @@
 import { Entity, Column, ManyToOne, OneToMany } from "typeorm";
 import { BaseEntity } from "../../../shared/base.entity";
+import { PostType } from "../../../shared/enum.shared";
 import { Bookmark } from "../../bookmark/entity/bookmark.entity";
 import { Category } from "../../category/entity/category.entity";
 import { Comment } from "../../comment/entity/comment.entity";
 import { Survey } from "../../survey/entity/survey.entity";
 import { User } from "../../user/entity/user.entity";
+import { PostTypeTransformer } from "../helper/post-type-transformer";
 
 @Entity()
 export class Post extends BaseEntity {
@@ -25,9 +27,10 @@ export class Post extends BaseEntity {
   @Column({
     type: "tinyint",
     default: 1,
+    transformer: new PostTypeTransformer(),
     comment: "게시글 종류 [1: post, 2: mbti, 3: survey, 4: notice]",
   })
-  type: number;
+  type: number | PostType;
 
   @Column({ length: "4", comment: "작성자 MBTI" })
   userMbti: string;
@@ -83,7 +86,7 @@ export class Post extends BaseEntity {
     isSecret: boolean,
     title: string,
     content: string,
-    postType: number
+    postType: PostType
   ) {
     const post = new Post();
     post.user = user;
@@ -96,33 +99,5 @@ export class Post extends BaseEntity {
     post.userMbti = user.mbti;
 
     return post;
-  }
-
-  static typeTo(type: string) {
-    switch (type) {
-      case "post":
-        return 1;
-      case "mbti":
-        return 2;
-      case "survey":
-        return 3;
-      case "notice":
-        return 4;
-      default: // typeTo undefined 막기 위해 추가
-        return 0;
-    }
-  }
-
-  static typeFrom(type: number) {
-    switch (type) {
-      case 1:
-        return "post";
-      case 2:
-        return "mbti";
-      case 3:
-        return "survey";
-      case 4:
-        return "notice";
-    }
   }
 }

--- a/src/modules/post/helper/post-type-transformer.ts
+++ b/src/modules/post/helper/post-type-transformer.ts
@@ -1,0 +1,34 @@
+import { ValueTransformer } from "typeorm";
+import { PostType } from "../../../shared/enum.shared";
+
+export class PostTypeTransformer implements ValueTransformer {
+  // entity -> db
+  to(type: PostType) {
+    switch (type) {
+      case "post":
+        return 1;
+      case "mbti":
+        return 2;
+      case "survey":
+        return 3;
+      case "notice":
+        return 4;
+      default: // typeTo undefined 막기 위해 추가
+        return 0;
+    }
+  }
+
+  // db -> entity
+  from(type: number) {
+    switch (type) {
+      case 1:
+        return "post";
+      case 2:
+        return "mbti";
+      case 3:
+        return "survey";
+      case 4:
+        return "notice";
+    }
+  }
+}

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -39,9 +39,9 @@ export class PostService implements IPostService {
       throw new NotFoundException("category id error");
     }
 
-    let postType = Post.typeTo(PostType.POST);
+    let postType = PostType.POST;
     if (category.name === CategoryName.MBTI) {
-      postType = Post.typeTo(PostType.MBTI);
+      postType = PostType.MBTI;
     }
 
     const postEntity = Post.of(
@@ -104,7 +104,7 @@ export class PostService implements IPostService {
     if (!post || !post.isActive) throw new NotFoundException("not exists post");
 
     // 타입이 mbti 일 경우
-    if (Post.typeFrom(post.type) === PostType.MBTI) {
+    if (post.type === PostType.MBTI) {
       if (user.mbti !== post.userMbti)
         throw new ForbiddenException("authorization error");
     }


### PR DESCRIPTION
## 개요
Post의
- type 컬럼 타입 tinyint 
- type 엔티티 타입 string

불일치를 매핑하기 위해 static함수 `typeTo`, `typeFrom`을 사용함

## 작업사항
TypeORM의 ValueTransformer 인터페이스를 구현한 클래스를 만든후,
Column 옵션 중 transformer에 사용함

## 변경로직

### 변경전
```
let postType = Post.typeTo(PostType.POST);
    if (category.name === CategoryName.MBTI) {
      postType = Post.typeTo(PostType.MBTI);
    }
```
### 변경후
```
let postType = PostType.POST;
    if (category.name === CategoryName.MBTI) {
      postType = PostType.MBTI;
    }

```
## 기타
