### PR TITLE
Fix: like post transformer

### DIFF
--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from "inversify";
 import { TYPES } from "../../core/types.core";
 import { IDatabaseService } from "../../core/database/interfaces/IDatabase.service";
-import { LikeTargetType } from "../../shared/enum.shared";
+import { LikeTargetType, PostType } from "../../shared/enum.shared";
 import {
   BadReqeustException,
   ForbiddenException,
@@ -47,7 +47,7 @@ export class LikeService implements ILikeService {
     if (type === LikeTargetType.POST) {
       aver_target = target as Post;
       if (
-        aver_target.type === Post.typeTo("mbti") &&
+        aver_target.type === PostType.MBTI &&
         user.mbti !== aver_target.userMbti
       )
         throw new ForbiddenException("authorization error");
@@ -58,7 +58,7 @@ export class LikeService implements ILikeService {
       const post = await this._postRepository.findOneById(aver_target.postId);
       if (!post || !post.isActive)
         throw new NotFoundException(`not exists post`);
-      if (post.type === Post.typeTo("mbti") && user.mbti !== post?.userMbti)
+      if (post.type === PostType.MBTI && user.mbti !== post?.userMbti)
         throw new ForbiddenException("authorization error");
     }
   }

--- a/src/modules/post/dto/post-response.dto.ts
+++ b/src/modules/post/dto/post-response.dto.ts
@@ -30,7 +30,7 @@ export class PostResponseDto {
     this.isMy = user ? user.isMy(post) : false;
     this.userId = post.userId;
     this.userMbti = post.userMbti;
-    this.userNickname = post.userNickname ?? "";
+    this.userNickname = post.userNickname ?? "anonymous";
     this.isSecret = post.isSecret;
     this.title = post.title;
     this.content = post.content;


### PR DESCRIPTION
## 개요
post transform 적용 내용이 like에는 반영되지 않음

## 작업사항
like service 에서 typeTo, typeFrom 사용하던 부분 수정

## 기타
익명으로 게시글 생성시 유저 닉네임 "" 으로 반환하였는데, 더 명확하개 "anonymous"로 반환