### PR TITLE
Update: redis url env

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,9 +41,6 @@ services:
       - MYSQL_USER=mbtichannel-user
       - MYSQL_PASSWORD=mbtichannel-pw
       - MYSQL_DB=mbtichannel-db
-      # redis
-      - REDIS_HOST=redis://mbtichannel-redis
-      - REDIS_PORT=6379
     depends_on:
       - redis
     restart: unless-stopped

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -66,10 +66,7 @@ export default {
     },
   },
   redis: {
-    redisUserName: isValidEnvVar("REDIS_USERNAME"),
-    redisPassword: isValidEnvVar("REDIS_PASSWORD"),
-    redisHost: isValidEnvVar("REDIS_HOST"),
-    redisPort: isValidEnvVar("REDIS_PORT"),
+    url: isValidEnvVar("REDIS_URL"),
   },
   discord: {
     askWebhookUrl: isValidEnvVar("DISCORD_ASK_WEBHOOK_URL"),

--- a/src/core/database/redis.service.ts
+++ b/src/core/database/redis.service.ts
@@ -17,10 +17,7 @@ export class RedisService implements IRedisService {
     this._logger.info(`[RedisService] redis init...`);
 
     RedisService._client = createClient({
-      url:
-        process.env.NODE_ENV === "production"
-          ? `redis://${redis.redisUserName}:${redis.redisPassword}@${redis.redisHost}:${redis.redisPort}`
-          : redis.redisHost,
+      url: redis.url,
     });
     RedisService._client.on("error", (err) => {
       this._logger.error(


### PR DESCRIPTION
## 개요
- redis 연결시 production인지 development인지 확인하고, redis.host, redis.port, redis.username, redis.password 통해서 연결

## 작업사항
- 간단히 .env에 redisUrl 을 넣어줘 간결화 및 개발용과 배포용을 config할 때 부터 분리

## 기타
- 환경변수를 클라이언트 쪽에서 가지고 있으니까 docker-compose 에서 environment 부분은 필요 없을꺼같은데 어떻게 생각하시나용?