### PR TITLE
Update: 댓글 조회 API 페이지네이션 수정

### DIFF
--- a/src/modules/comment/comment.controller.ts
+++ b/src/modules/comment/comment.controller.ts
@@ -95,7 +95,7 @@ export class CommentController {
     res: Response
   ) {
     const user = req.user as User;
-    const data = await this._commentService.findAllComments(query, user);
+    const data = await this._commentService.getAllComments(query, user);
     return res.status(200).json(data);
   }
 
@@ -111,7 +111,7 @@ export class CommentController {
     res: Response
   ) {
     const user = req.user as User;
-    const data = await this._commentService.findAllReplies(query, user);
+    const data = await this._commentService.getAllReplies(query, user);
     return res.status(200).json(data);
   }
 

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -159,7 +159,7 @@ export class CommentService implements ICommentService {
     }
   }
 
-  public async findAllComments(pageOptionsDto: GetAllCommentDto, user: User) {
+  public async getAllComments(pageOptionsDto: GetAllCommentDto, user: User) {
     this._log(`findAllComments start`);
     // 댓글을 조회할 게시글이 존재하는지 확인
     const isValidPost = this._postService.isValid(pageOptionsDto.postId);
@@ -181,7 +181,7 @@ export class CommentService implements ICommentService {
     );
   }
 
-  public async findAllReplies(
+  public async getAllReplies(
     pageOptionsDto: GetAllRepliesDto,
     user: User
   ): Promise<any> {

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -161,18 +161,21 @@ export class CommentService implements ICommentService {
 
   public async getAllComments(pageOptionsDto: GetAllCommentDto, user: User) {
     this._log(`findAllComments start`);
+    const { postId, maxResults, page } = pageOptionsDto;
     // 댓글을 조회할 게시글이 존재하는지 확인
-    const isValidPost = this._postService.isValid(pageOptionsDto.postId);
-    if (!isValidPost) throw new NotFoundException("not exists post");
+    const foundPost = await this._postRepository.findOneById(postId);
+    if (!foundPost || !foundPost.isActive)
+      throw new NotFoundException("not exists post");
 
-    const [commentArray, totalCount] =
-      await this._commentRepository.findAllComments(pageOptionsDto);
+    const commentArray = await this._commentRepository.findAllComments(
+      pageOptionsDto
+    );
 
     // 페이지 정보
     const pageInfoDto = new PageInfoDto(
-      totalCount,
-      commentArray.length,
-      pageOptionsDto.page
+      foundPost.commentCount,
+      maxResults,
+      page
     );
 
     return new PageResponseDto(

--- a/src/modules/comment/interfaces/IComment.repository.ts
+++ b/src/modules/comment/interfaces/IComment.repository.ts
@@ -4,9 +4,7 @@ import { Comment } from "../entity/comment.entity";
 export interface ICommentRepository {
   createComment(commentEntity: Comment): Promise<Comment>;
   findOneById(id: number): Promise<Comment | null>;
-  findAllComments(
-    pageOptionsDto: GetAllCommentDto
-  ): Promise<[Comment[], number]>;
+  findAllComments(pageOptionsDto: GetAllCommentDto): Promise<Comment[]>;
   findAllReplies(
     pageOptionsDto: GetAllRepliesDto
   ): Promise<[Comment[], number]>;

--- a/src/modules/comment/interfaces/IComment.service.ts
+++ b/src/modules/comment/interfaces/IComment.service.ts
@@ -28,11 +28,11 @@ export interface ICommentService {
     content: string,
     isSecret: boolean
   ): Promise<ReplyResponseDto>;
-  findAllComments(
+  getAllComments(
     pageOptionsDto: GetAllCommentDto,
     user: User
   ): Promise<PageResponseDto<PageInfoDto, CommentResponseDto>>;
-  findAllReplies(
+  getAllReplies(
     pageOptionsDto: GetAllRepliesDto,
     user: User
   ): Promise<PageResponseDto<PageInfiniteScrollInfoDto, ReplyResponseDto>>;
@@ -45,5 +45,5 @@ export interface ICommentService {
   decreaseLikeCount(id: number): Promise<void>;
   update(user: User, id: number, content: string): Promise<CommentResponseDto>;
   delete(user: User, id: number): Promise<void>;
-  isValid(id:number): Promise<boolean>
+  isValid(id: number): Promise<boolean>;
 }


### PR DESCRIPTION
## 개요
더미데이터 약 천만건 이상에서 페이징조회가 50초~1분 이상이 소요되는 문제가 발견
## 변경로직
* pageInfoDto: itemsPerPage인자 maxResults로 수정하여 잘못된 전체 페이지 계산 수정
* 쿼리빌더 api getManyAndCount->getMany로 수정하여 COUNT 쿼리 제거
* totalCount: COUNT 쿼리반환값에서 post 엔티티의 comment count값으로 수정

https://github.com/MBTI-Channel/server/issues/89#issuecomment-1210491906 에서 정리했듯이
생성순으로 조회는 `4초이상` -> `1초미만 ms`로 개선했어요
## 기타
좋아요 순으로 정렬할 경우에는 인덱스를 타지않고 전체 댓글 low조회 후 정렬하는 듯 합니다.
속도가 여전히 느리네요..