### PR TITLE
Update: page info dto 변수명에 맞게 수정

### DIFF
--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -174,8 +174,9 @@ export class CommentService implements ICommentService {
     // 페이지 정보
     const pageInfoDto = new PageInfoDto(
       foundPost.commentCount,
-      maxResults,
-      page
+      commentArray.length,
+      page,
+      maxResults
     );
 
     return new PageResponseDto(
@@ -223,6 +224,7 @@ export class CommentService implements ICommentService {
     pageOptionsDto: GetAllByUserDto
   ): Promise<PageResponseDto<PageInfoDto, UserCommentResponseDto>> {
     const { id: userId } = user;
+    const { page, maxResults } = pageOptionsDto;
 
     const [commentArray, totalCount] =
       await this._commentRepository.findAllByUser(pageOptionsDto, userId);
@@ -231,7 +233,8 @@ export class CommentService implements ICommentService {
     const pageInfoDto = new PageInfoDto(
       totalCount,
       commentArray.length,
-      pageOptionsDto.page
+      page,
+      maxResults
     );
 
     return new PageResponseDto(

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -178,6 +178,7 @@ export class PostService implements IPostService {
   // 내가 작성한 게시글 조회
   public async getMyPosts(user: User, pageOptionsDto: GetMyPostsDto) {
     const { id } = user;
+    const { page, maxResults } = pageOptionsDto;
     const [myPostArray, totalCount] =
       await this._postRepository.findAllByUserId(pageOptionsDto, id);
 
@@ -185,7 +186,8 @@ export class PostService implements IPostService {
     const pageInfoDto = new PageInfoDto(
       totalCount,
       myPostArray.length,
-      pageOptionsDto.page
+      page,
+      maxResults
     );
 
     return new PageResponseDto(

--- a/src/shared/page/dto/page-info.dto.ts
+++ b/src/shared/page/dto/page-info.dto.ts
@@ -4,11 +4,21 @@ export class PageInfoDto {
   currentPage: number;
   totalPage: number;
 
-  constructor(totalCount: number, itemsPerPage: number, currentPage: number) {
+  /**
+   * @param totalCount   전체 아이템 수
+   * @param itemsPerPage 페이지당 아이템 수
+   * @param currentPage  현재 페이지
+   * @param maxResults   페이지당 출력 아이템 수
+   */
+  constructor(
+    totalCount: number,
+    itemsPerPage: number,
+    currentPage: number,
+    maxResults: number
+  ) {
     this.totalCount = totalCount;
     this.itemsPerPage = itemsPerPage;
     this.currentPage = currentPage;
-    this.totalPage =
-      totalCount === 0 ? 1 : Math.ceil(totalCount / itemsPerPage);
+    this.totalPage = totalCount === 0 ? 1 : Math.ceil(totalCount / maxResults);
   }
 }


### PR DESCRIPTION
## 개요
```ts
totalCount === 0 ? 1 : Math.ceil(totalCount / itemsPerPage);
```
PageInfoDto의 생성자의 `totalCount` 계산식에서, 분모 `itemsPerPage`는 코드상에서 실제로는 페이지당 출력 수인 `maxResults`를 넣고 있는 상태.
페이지당 아이템 수라는 `itemsPerPage`이름과 실제 들어가는  maxResults 뜻이 맞지 않았다.

## 변경로직
### 변경전
PageInfoDto 인스턴스를 만들때, `itemsPerPage`에는 `totalCount`계산을 위해 `maxResults`값이 들어갔다.
```ts
constructor(totalCount: number, itemsPerPage: number, currentPage: number)  {
    this.totalCount = totalCount;
    this.itemsPerPage = itemsPerPage;
    this.currentPage = currentPage;
    this.totalPage =
    totalCount === 0 ? 1 : Math.ceil(totalCount / itemsPerPage);
  }

```
### 변경후
```ts
export class PageInfoDto {
  totalCount: number;
  itemsPerPage: number;
  currentPage: number;
  totalPage: number;

  /**
   * @param totalCount   전체 아이템 수
   * @param itemsPerPage 페이지당 아이템 수
   * @param currentPage  현재 페이지
   * @param maxResults   페이지당 출력 아이템 수
   */
  constructor(
    totalCount: number,
    itemsPerPage: number,
    currentPage: number,
    maxResults: number
  ) {
    this.totalCount = totalCount;
    this.itemsPerPage = itemsPerPage;
    this.currentPage = currentPage;
    this.totalPage = totalCount === 0 ? 1 : Math.ceil(totalCount / maxResults);
  }
}


//인스턴스 생성시
    const pageInfoDto = new PageInfoDto(
      totalCount,
      myPostArray.length,
      page,
      maxResults
    );
```
