### PR TITLE
Fea: 회원 탈퇴 API

### DIFF
--- a/src/core/database/interfaces/IRedis.service.ts
+++ b/src/core/database/interfaces/IRedis.service.ts
@@ -2,4 +2,5 @@ export interface IRedisService {
   init(): Promise<void>;
   set(key: string, value: string): Promise<void>;
   get(key: string): Promise<string>;
+  del(key: string): Promise<void>;
 }

--- a/src/core/database/redis.service.ts
+++ b/src/core/database/redis.service.ts
@@ -45,4 +45,8 @@ export class RedisService implements IRedisService {
     }
     return value;
   }
+
+  public async del(key: string) {
+    await RedisService._client.del(key);
+  }
 }

--- a/src/core/types.core.ts
+++ b/src/core/types.core.ts
@@ -50,6 +50,9 @@ export const TYPES = {
   SocialSignUpMiddleware: Symbol.for("SocialSignUpMiddleware"),
   ValidateAccessTokenMiddleware: Symbol.for("ValidateAccessTokenMiddleware"),
   ValidateReissueTokenMiddleware: Symbol.for("ValidateReissueTokenMiddleware"),
+  ValidateAccessRefreshTokenMiddleware: Symbol.for(
+    "ValidateAccessRefreshTokenMiddleware"
+  ),
   CheckLoginStatusMiddleware: Symbol.for("CheckLoginStatusMiddleware"),
   /* shared */
   IApiWebhookService: Symbol.for("IApiWebhookService"),

--- a/src/middlewares/middleware.module.ts
+++ b/src/middlewares/middleware.module.ts
@@ -3,6 +3,7 @@ import { TYPES } from "../core/types.core";
 import { CheckLoginStatus } from "./check-login-status.middleware";
 import { GetProviderUserByOauth } from "./get-provider-user-by-oauth.middleware";
 import { SocialSignUp } from "./social-sign-up.middleware";
+import { ValidateAccessRefreshToken } from "./validate-access-refresh-token.middleware";
 import { ValidateAccessToken } from "./validate-access-token.middleware";
 import { ValidateReissueToken } from "./validate-reissue-token.middleware";
 
@@ -11,5 +12,8 @@ export const middlewareModule = new ContainerModule((bind) => {
   bind(TYPES.SocialSignUpMiddleware).to(SocialSignUp);
   bind(TYPES.ValidateAccessTokenMiddleware).to(ValidateAccessToken);
   bind(TYPES.ValidateReissueTokenMiddleware).to(ValidateReissueToken);
+  bind(TYPES.ValidateAccessRefreshTokenMiddleware).to(
+    ValidateAccessRefreshToken
+  );
   bind(TYPES.CheckLoginStatusMiddleware).to(CheckLoginStatus);
 });

--- a/src/middlewares/validate-access-refresh-token.middleware.ts
+++ b/src/middlewares/validate-access-refresh-token.middleware.ts
@@ -1,0 +1,94 @@
+import { plainToInstance } from "class-transformer";
+import { NextFunction, Request, Response } from "express";
+import { inject, injectable } from "inversify";
+import { BaseMiddleware } from "inversify-express-utils";
+import { TYPES } from "../core/types.core";
+import { IAuthService } from "../modules/auth/interfaces/IAuth.service";
+import { User } from "../modules/user/entity/user.entity";
+import { UnauthorizedException } from "../shared/errors/all.exception";
+import { JwtUtil } from "../shared/utils/jwt.util";
+import { Logger } from "../shared/utils/logger.util";
+
+@injectable()
+export class ValidateAccessRefreshToken extends BaseMiddleware {
+  constructor(
+    @inject(TYPES.Logger) private readonly _logger: Logger,
+    @inject(TYPES.JwtUtil) private readonly _jwtUtil: JwtUtil,
+    @inject(TYPES.IAuthService) private readonly _authService: IAuthService
+  ) {
+    super();
+  }
+
+  private _log(message: string) {
+    this._logger.trace(`[ValidateAccessRefreshToken] ${message}`);
+  }
+
+  async handler(req: Request, res: Response, next: NextFunction) {
+    try {
+      this._log(`start`);
+      const AUTH_TYPE = "Bearer ";
+      const header = req.headers.authorization;
+
+      let accessToken: string;
+      let refreshToken: string;
+
+      // 요청 헤더와 타입이 맞다면 accessToken 할당
+      if (header && header.startsWith(AUTH_TYPE)) {
+        accessToken = header.split(" ")[1];
+      } else {
+        this._log(
+          `access token not in 'authorization' header or 'Bearer ' type`
+        );
+        throw new UnauthorizedException("authentication error");
+      }
+
+      // access token 유효 여부 판단
+      const decoded = this._jwtUtil.verify(accessToken);
+      if (decoded.status === "invalid") {
+        this._log(`jwt verify error`);
+        throw new UnauthorizedException("authentication error");
+      }
+      if (decoded.status === "expired") {
+        this._log(`jwt expired`);
+        throw new UnauthorizedException("access token expired");
+      }
+
+      // access token의 payload가 유효한 사용자 확인
+      const { id, nickname, mbti } = decoded;
+      await this._authService.validateUserWithToken(id, nickname, mbti);
+
+      // refresh token이 쿠키에 있는지 확인
+      refreshToken = req.cookies.Refresh;
+      if (!refreshToken) {
+        this._log(`refresh token not in cookie error`);
+        throw new UnauthorizedException("authentication error");
+      }
+
+      // refresh token 검증
+      const { status: refreshTokenStatus } = this._jwtUtil.verify(refreshToken);
+      if (refreshTokenStatus === "invalid") {
+        this._log(`inavlid refresh token`);
+        res.clearCookie("Refresh");
+        throw new UnauthorizedException("authentication error");
+      }
+      if (refreshTokenStatus === "expired") {
+        this._log(`expired refresh token`);
+        res.clearCookie("Refresh");
+        throw new UnauthorizedException("authentication error");
+      }
+
+      req.user = plainToInstance(User, {
+        id: decoded.id,
+        nickname: decoded.nickname,
+        mbti: decoded.mbti,
+        isAdmin: decoded.isAdmin,
+        createdAt: decoded.createdAt,
+      });
+
+      this._log(`call next`);
+      return next();
+    } catch (err) {
+      return next(err);
+    }
+  }
+}

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -103,4 +103,9 @@ export class AuthService implements IAuthService {
 
     await this._redisService.set(key, refreshToken);
   }
+
+  public async removeRefreshKey(key: string) {
+    this._log(`removeRefreshKey start`);
+    await this._redisService.del(key);
+  }
 }

--- a/src/modules/auth/interfaces/IAuth.service.ts
+++ b/src/modules/auth/interfaces/IAuth.service.ts
@@ -9,4 +9,5 @@ export interface IAuthService {
     mbti: string
   ): Promise<void>;
   hasRefreshAuth(key: string, refreshToken: string): Promise<boolean>;
+  removeRefreshKey(key: string): Promise<void>;
 }

--- a/src/modules/comment/comment.repository.ts
+++ b/src/modules/comment/comment.repository.ts
@@ -118,7 +118,7 @@ export class CommentRepository implements ICommentRepository {
       .innerJoin("comment.post", "post", "post.id = comment.postId")
       .take(pageOptionsDto.maxResults)
       .skip(pageOptionsDto.skip)
-      .orderBy(`comment.createdAt`, "DESC")
+      .orderBy(`comment.id`, "DESC")
       .getManyAndCount();
   }
 

--- a/src/modules/user/interfaces/IUser.service.ts
+++ b/src/modules/user/interfaces/IUser.service.ts
@@ -26,6 +26,7 @@ export interface IUserService {
     mbti: string,
     userAgent: string
   ): Promise<UserTokenResponseDto>;
+  leave(id: number, refreshToken: string, userAgent: string): Promise<void>;
   reissueAccessToken(
     user: User,
     refreshToken: string,

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { inject } from "inversify";
 import {
   controller,
+  httpDelete,
   httpGet,
   httpPatch,
   httpPost,
@@ -121,6 +122,20 @@ export class UserController {
     const data = req.user as User;
 
     return res.status(200).json(data);
+  }
+
+  //사용자 탈퇴
+  @httpDelete("/me", TYPES.ValidateAccessRefreshTokenMiddleware)
+  public async leave(req: Request, res: Response) {
+    const user = req.user as User;
+    const refreshToken = req.cookies.Refresh;
+    const userAgent = convertUserAgent(req.headers["user-agent"]);
+
+    await this._userService.leave(user.id, refreshToken, userAgent);
+
+    res.clearCookie("Refresh");
+
+    return res.status(204).end();
   }
 
   // 닉네임 업데이트


### PR DESCRIPTION
## 개요
회원 탈퇴 API
## 작업사항
- access, refresh token 검증 미들웨어 추가
- redis 키로 데이터 삭제 메서드 추가
- 유저 탈퇴 API 구현

## 기타
- 새로 추가된 미들웨어, `RedisService.del()`은 PR을 나누려 했으나 머지시간까지 걸릴 것같아 부득이하게 같이 PR을 올렸습니다
- 스웨거는 머지된 후 따로 PR 작성 예정