### PR TITLE
Update: posts pagination

### DIFF
--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -208,7 +208,6 @@ export class CommentService implements ICommentService {
 
     // 응답 DTO로 변환후 리턴
     const pageInfoDto = new PageInfiniteScrollInfoDto(
-      comment.replyCount,
       replyArray.length,
       nextId
     );

--- a/src/modules/notifications/notification.service.ts
+++ b/src/modules/notifications/notification.service.ts
@@ -74,7 +74,6 @@ export class NotificationService implements INotificationService {
 
     // 응답 DTO로 변환후 리턴
     const pageInfoDto = new PageInfiniteScrollInfoDto(
-      totalCount,
       notificationArray.length,
       nextId
     );

--- a/src/modules/post/interfaces/IPost.repository.ts
+++ b/src/modules/post/interfaces/IPost.repository.ts
@@ -18,12 +18,12 @@ export interface IPostRepository {
   findAllPosts(
     pageOptionsDto: GetAllPostDto,
     categoryId: number
-  ): Promise<[Post[], number]>;
+  ): Promise<Post[]>;
   findAllPostsWithMbti(
     pageOptionsDto: GetAllPostDto,
     categoryId: number,
     mbti: string
-  ): Promise<[Post[], number]>;
+  ): Promise<Post[]>;
   update(id: number, payload: Partial<Post>): Promise<Post>;
   findAllByUserId(
     pageOptionsDto: GetMyPostsDto,

--- a/src/modules/post/interfaces/IPost.repository.ts
+++ b/src/modules/post/interfaces/IPost.repository.ts
@@ -32,15 +32,13 @@ export interface IPostRepository {
   searchInCategory(
     pageOptionsDto: SearchPostDto,
     categoryId: number
-  ): Promise<[Post[], number]>;
+  ): Promise<Post[]>;
   searchInMbtiCategory(
     pageOptionsDto: SearchPostDto,
     categoryId: number,
     mbti: string
-  ): Promise<[Post[], number]>;
-  searchTrend(pageOptionsDto: GetTrendDto): Promise<[Post[], number]>;
-  searchAll(): Promise<[Post[], number]>;
-  searchWithoutMbtiCategory(
-    pageOptionsDto: SearchPostDto
-  ): Promise<[Post[], number]>;
+  ): Promise<Post[]>;
+  searchTrend(pageOptionsDto: GetTrendDto): Promise<Post[]>;
+  searchAll(): Promise<Post[]>;
+  searchWithoutMbtiCategory(pageOptionsDto: SearchPostDto): Promise<Post[]>;
 }

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -76,9 +76,9 @@ export class PostRepository implements IPostRepository {
   public async findAllPosts(
     pageOptionsDto: GetAllPostDto,
     categoryId: number
-  ): Promise<[Post[], number]> {
+  ): Promise<Post[]> {
     const repository = await this._database.getRepository(Post);
-    const [result, totalCount] = await repository.findAndCount({
+    const result = await repository.find({
       select: [
         "id",
         "categoryId",
@@ -100,18 +100,18 @@ export class PostRepository implements IPostRepository {
       where: { categoryId },
       take: pageOptionsDto.maxResults + 1,
       skip: pageOptionsDto.skip,
-      order: { [pageOptionsDto.order]: "DESC" },
+      order: { id: "DESC" },
     });
-    return [result, totalCount];
+    return result;
   }
 
   public async findAllPostsWithMbti(
     pageOptionsDto: GetAllPostDto,
     categoryId: number,
     mbti: string
-  ): Promise<[Post[], number]> {
+  ): Promise<Post[]> {
     const repository = await this._database.getRepository(Post);
-    const [result, totalCount] = await repository.findAndCount({
+    const result = await repository.find({
       select: [
         "id",
         "categoryId",
@@ -133,9 +133,9 @@ export class PostRepository implements IPostRepository {
       where: { categoryId, userMbti: mbti },
       take: pageOptionsDto.maxResults + 1,
       skip: pageOptionsDto.skip,
-      order: { [pageOptionsDto.order]: "DESC" },
+      order: { id: "DESC" },
     });
-    return [result, totalCount];
+    return result;
   }
 
   // 일반 페이지네이션

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -166,7 +166,7 @@ export class PostRepository implements IPostRepository {
       .where("post.user_id = :userId", { userId })
       .take(pageOptionsDto.maxResults)
       .skip(pageOptionsDto.skip)
-      .orderBy(`post.createdAt`, "DESC")
+      .orderBy(`post.id`, "DESC")
       .getManyAndCount();
   }
 
@@ -180,9 +180,9 @@ export class PostRepository implements IPostRepository {
   public async searchInCategory(
     pageOptionsDto: SearchPostDto,
     categoryId: number
-  ): Promise<[Post[], number]> {
+  ): Promise<Post[]> {
     const repository = await this._database.getRepository(Post);
-    const [result, totalCount] = await repository.findAndCount({
+    const result = await repository.find({
       select: [
         "id",
         "categoryId",
@@ -204,18 +204,18 @@ export class PostRepository implements IPostRepository {
       where: { categoryId, title: Like(`%${pageOptionsDto.searchWord}%`) },
       take: pageOptionsDto.maxResults + 1,
       skip: pageOptionsDto.skip,
-      order: { [pageOptionsDto.order]: "DESC" },
+      order: { id: "DESC" },
     });
-    return [result, totalCount];
+    return result;
   }
 
   public async searchInMbtiCategory(
     pageOptionsDto: SearchPostDto,
     categoryId: number,
     mbti: string
-  ): Promise<[Post[], number]> {
+  ): Promise<Post[]> {
     const repository = await this._database.getRepository(Post);
-    const [result, totalCount] = await repository.findAndCount({
+    const result = await repository.find({
       select: [
         "id",
         "categoryId",
@@ -241,16 +241,16 @@ export class PostRepository implements IPostRepository {
       },
       take: pageOptionsDto.maxResults + 1,
       skip: pageOptionsDto.skip,
-      order: { [pageOptionsDto.order]: "DESC" },
+      order: { id: "DESC" },
     });
-    return [result, totalCount];
+    return result;
   }
 
   public async searchWithoutMbtiCategory(
     pageOptionsDto: SearchPostDto
-  ): Promise<[Post[], number]> {
+  ): Promise<Post[]> {
     const repository = await this._database.getRepository(Post);
-    const [result, totalCount] = await repository.findAndCount({
+    const result = await repository.find({
       select: [
         "id",
         "categoryId",
@@ -279,17 +279,15 @@ export class PostRepository implements IPostRepository {
       },
       take: pageOptionsDto.maxResults + 1,
       skip: pageOptionsDto.skip,
-      order: { [pageOptionsDto.order]: "DESC" },
+      order: { id: "DESC" },
     });
-    return [result, totalCount];
+    return result;
   }
 
   // 인기글 검색
-  public async searchTrend(
-    pageOptionsDto: GetTrendDto
-  ): Promise<[Post[], number]> {
+  public async searchTrend(pageOptionsDto: GetTrendDto): Promise<Post[]> {
     const repository = await this._database.getRepository(Post);
-    const [result, totalCount] = await repository.findAndCount({
+    const result = await repository.find({
       select: [
         "id",
         "categoryId",
@@ -299,6 +297,7 @@ export class PostRepository implements IPostRepository {
         "userNickname",
         "userMbti",
         "isSecret",
+        "isTrend",
         "title",
         "content",
         "viewCount",
@@ -311,14 +310,14 @@ export class PostRepository implements IPostRepository {
       where: { isTrend: true },
       take: pageOptionsDto.maxResults + 1,
       skip: pageOptionsDto.skip,
-      order: { [pageOptionsDto.order]: "DESC" },
+      order: { id: "DESC" },
     });
-    return [result, totalCount];
+    return result;
   }
 
-  public async searchAll(): Promise<[Post[], number]> {
+  public async searchAll(): Promise<Post[]> {
     const repository = await this._database.getRepository(Post);
     // 수정 필요
-    return [[], 0];
+    return [];
   }
 }

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -260,11 +260,7 @@ export class PostService implements IPostService {
     }
     let itemsPerPage = postArray.length;
 
-    const pageInfoDto = new PageInfiniteScrollInfoDto(
-      totalCount, // 결과에 맞는 개수
-      itemsPerPage,
-      nextId
-    );
+    const pageInfoDto = new PageInfiniteScrollInfoDto(itemsPerPage, nextId);
 
     return new PageResponseDto(
       pageInfoDto,
@@ -285,20 +281,20 @@ export class PostService implements IPostService {
     if (!category || !category.isActive) {
       throw new NotFoundException("not exists category");
     }
-    let postArray, totalCount;
+    let postArray;
 
     if (!user && pageOptionsDto.category === CategoryName.MBTI) {
       throw new ForbiddenException("not authorizatie");
     }
 
     if (pageOptionsDto.category === CategoryName.MBTI) {
-      [postArray, totalCount] = await this._postRepository.findAllPostsWithMbti(
+      postArray = await this._postRepository.findAllPostsWithMbti(
         pageOptionsDto,
         category.id,
         user.mbti
       );
     } else {
-      [postArray, totalCount] = await this._postRepository.findAllPosts(
+      postArray = await this._postRepository.findAllPosts(
         pageOptionsDto,
         category.id
       );
@@ -311,11 +307,7 @@ export class PostService implements IPostService {
     }
     let itemsPerPage = postArray.length;
 
-    const pageInfoDto = new PageInfiniteScrollInfoDto(
-      totalCount, // 결과에 맞는 개수
-      itemsPerPage,
-      nextId
-    );
+    const pageInfoDto = new PageInfiniteScrollInfoDto(itemsPerPage, nextId);
 
     return new PageResponseDto(
       pageInfoDto,
@@ -404,11 +396,7 @@ export class PostService implements IPostService {
     }
     let itemsPerPage = postArray.length;
 
-    const pageInfoDto = new PageInfiniteScrollInfoDto(
-      totalCount, // 결과에 맞는 개수
-      itemsPerPage,
-      nextId
-    );
+    const pageInfoDto = new PageInfiniteScrollInfoDto(itemsPerPage, nextId);
 
     return new PageResponseDto(
       pageInfoDto,

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -356,7 +356,7 @@ export class PostService implements IPostService {
           pageOptionsDto
         );
       } else {
-        // user가 있으므로 user에 맞는 mbti 게시글 포함
+        // TODO: user가 있으므로 user에 맞는 mbti 게시글 포함
       }
     } else {
       // 카테고리가 있을 경우 유효성 검사 후 카테고리에 따라 검색

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -248,10 +248,8 @@ export class PostService implements IPostService {
   ): Promise<PageResponseDto<PageInfiniteScrollInfoDto, PostResponseDto>> {
     this._log(`getTrends start`);
 
-    let postArray, totalCount;
-    [postArray, totalCount] = await this._postRepository.searchTrend(
-      pageOptionsDto
-    );
+    let postArray;
+    postArray = await this._postRepository.searchTrend(pageOptionsDto);
 
     let nextId = null;
     if (postArray.length === pageOptionsDto.maxResults + 1) {
@@ -348,15 +346,15 @@ export class PostService implements IPostService {
     this._log(`search start`);
 
     let postArray: Post[] = [];
-    let totalCount = 0;
 
     if (!pageOptionsDto.category) {
       // category가 없을 경우 게시글 전체 검색
       this._log(`search all posts`);
       if (!user) {
         // user가 없으므로 mbti 카테고리는 제외
-        [postArray, totalCount] =
-          await this._postRepository.searchWithoutMbtiCategory(pageOptionsDto);
+        postArray = await this._postRepository.searchWithoutMbtiCategory(
+          pageOptionsDto
+        );
       } else {
         // user가 있으므로 user에 맞는 mbti 게시글 포함
       }
@@ -375,14 +373,13 @@ export class PostService implements IPostService {
       }
       this._log(`search posts in category: ${pageOptionsDto.category}`);
       if (pageOptionsDto.category === CategoryName.MBTI) {
-        [postArray, totalCount] =
-          await this._postRepository.searchInMbtiCategory(
-            pageOptionsDto,
-            category.id,
-            user.mbti
-          );
+        postArray = await this._postRepository.searchInMbtiCategory(
+          pageOptionsDto,
+          category.id,
+          user.mbti
+        );
       } else {
-        [postArray, totalCount] = await this._postRepository.searchInCategory(
+        postArray = await this._postRepository.searchInCategory(
           pageOptionsDto,
           category.id
         );

--- a/src/shared/page/dto/page-infinite-scroll-info.dto.ts
+++ b/src/shared/page/dto/page-infinite-scroll-info.dto.ts
@@ -1,10 +1,12 @@
 export class PageInfiniteScrollInfoDto {
-  totalCount: number;
   itemsPerPage: number;
   nextId: number | null;
 
-  constructor(totalCount: number, itemsPerPage: number, nextId: number | null) {
-    this.totalCount = totalCount;
+  /**
+   * @param itemsPerPage 페이지당 아이템 수
+   * @param nextId 다음 게시글 id
+   */
+  constructor(itemsPerPage: number, nextId: number | null) {
     this.itemsPerPage = itemsPerPage;
     this.nextId = nextId;
   }


### PR DESCRIPTION
## 개요
5천만개의 더미 데이터로 테스트 해본 결과 페이징 조회가 1분 이상 소요됨. 

## 작업사항
- PageInfiniteScrollInfoDto 에서 totalCount 제거
- TypeORM findAndCount 대신 find 사용 

## 기타
- 인기게시글 조회를 하고 싶을 때, `where { isTrend: true }` 로 인기게시글인 것을 받아오는데, 5천만개의 더미 데이터중 인기게시글이 maxResults보다 적으면, 처음부터 끝까지 돌아서 시간이 오래걸린다..
- 자잘한 오류 발견했는데, 머지 후 고치도록 할게요
- `skip = offset take =limit` skip은 일반 페이지에서 사용하자~

issue: #89 