### PR TITLE
Fix: 회원가입 API 쿠키에 Refresh 설정 추가

### DIFF
--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -61,7 +61,7 @@ export class UserController {
 
     res.cookie("Refresh", data.refreshToken, {
       httpOnly: true,
-      secure: false, // true
+      secure: process.env.NODE_ENV === "production" ? true : false,
       maxAge: config.cookie.refreshTokenMaxAge,
     });
 
@@ -98,7 +98,7 @@ export class UserController {
 
     res.cookie("Refresh", data.refreshToken, {
       httpOnly: true,
-      secure: false, // true
+      secure: process.env.NODE_ENV === "production" ? true : false,
       maxAge: config.cookie.refreshTokenMaxAge,
     });
 

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -58,6 +58,13 @@ export class UserController {
       mbti,
       userAgent
     );
+
+    res.cookie("Refresh", data.refreshToken, {
+      httpOnly: true,
+      secure: false, // true
+      maxAge: config.cookie.refreshTokenMaxAge,
+    });
+
     return res.status(201).json(data);
   }
 


### PR DESCRIPTION
## 개요
회원가입 API에서 쿠키에 refresh 설정을 안해주는걸 발견
## 작업사항
- 쿠키 세팅 코드 추가함
- 쿠키 옵션 secure 환경변수에 따라 동적으로 변하게 수정
