### PR TITLE
Feat: 로그아웃 API

### DIFF
--- a/src/modules/user/interfaces/IUser.service.ts
+++ b/src/modules/user/interfaces/IUser.service.ts
@@ -19,6 +19,7 @@ export interface IUserService {
     providerId: string,
     userAgent: string
   ): Promise<UserTokenResponseDto>;
+  logout(id: number, refreshToken: string, userAgent: string): Promise<void>;
   signUp(
     id: number,
     uuid: string,

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -100,6 +100,18 @@ export class UserController {
     return res.status(201).json(data);
   }
 
+  // 로그아웃
+  @httpDelete("/logout", TYPES.ValidateAccessRefreshTokenMiddleware)
+  public async logout(req: Request, res: Response) {
+    const { id } = req.user as User;
+    const refreshToken = req.cookies.Refresh;
+    const userAgent = convertUserAgent(req.headers["user-agent"]);
+
+    await this._userService.logout(id, refreshToken, userAgent);
+
+    return res.status(204).end();
+  }
+
   // access token 재발급
   @httpGet("/accessToken", TYPES.ValidateReissueTokenMiddleware)
   public async reissueAccessToken(req: Request, res: Response) {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -106,6 +106,23 @@ export class UserService implements IUserService {
     return new UserTokenResponseDto(user, accessToken, refreshToken);
   }
 
+  public async logout(id: number, refreshToken: string, userAgent: string) {
+    this._log(`logout start`);
+
+    // redis에 있는 refresh 상태 삭제
+    this._log(`check refresh status`);
+    const key = `${id}-${userAgent}`;
+    const hasAuth = await this._authService.hasRefreshAuth(key, refreshToken);
+    if (!hasAuth) {
+      //TODO: 디스코드 알림
+      this._logger.warn(
+        `[UserService] warning! suspected token theft user: ${id}`
+      );
+      throw new UnauthorizedException("authentication error");
+    }
+    await this._authService.removeRefreshKey(key);
+  }
+
   // 닉네임, mbti를 update하여 회원가입 처리한다.
   public async signUp(
     id: number,


### PR DESCRIPTION
## 개요
로그아웃 API 구현
## 작업사항
로그아웃 API 구현
- access token, refresh token 필요
- 레디스에 보관한 refresh 상테 삭제
- 클라이언트 쿠키 refresh 삭제
## 기타
swagger는 회원 탈퇴 API와 함께 PR 나눠서 진행하겠습니당
