### PR TITLE
Update: post pagination nextId

### DIFF
--- a/src/modules/post/dto/get-all-post.dto.ts
+++ b/src/modules/post/dto/get-all-post.dto.ts
@@ -30,8 +30,4 @@ export class GetAllPostDto {
   @IsEnum(PostOrder)
   @IsOptional()
   order: PostOrder = PostOrder.CREATED_AT;
-
-  get skip(): number {
-    return this.startId;
-  }
 }

--- a/src/modules/post/dto/get-trend.dto.ts
+++ b/src/modules/post/dto/get-trend.dto.ts
@@ -19,8 +19,4 @@ export class GetTrendDto {
   @IsEnum(PostOrder)
   @IsOptional()
   order: PostOrder = PostOrder.CREATED_AT;
-
-  get skip(): number {
-    return this.startId;
-  }
 }

--- a/src/modules/post/dto/search-post.dto.ts
+++ b/src/modules/post/dto/search-post.dto.ts
@@ -27,8 +27,4 @@ export class SearchPostDto {
   @IsString()
   @IsOptional()
   searchWord: string = "";
-
-  get skip(): number {
-    return this.startId;
-  }
 }

--- a/src/modules/post/interfaces/IPost.repository.ts
+++ b/src/modules/post/interfaces/IPost.repository.ts
@@ -38,7 +38,7 @@ export interface IPostRepository {
     categoryId: number,
     mbti: string
   ): Promise<Post[]>;
-  searchTrend(pageOptionsDto: GetTrendDto): Promise<Post[]>;
+  findAllTrends(pageOptionsDto: GetTrendDto): Promise<Post[]>;
   searchAll(): Promise<Post[]>;
   searchWithoutMbtiCategory(pageOptionsDto: SearchPostDto): Promise<Post[]>;
 }

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -253,6 +253,7 @@ export class PostRepository implements IPostRepository {
   public async searchWithoutMbtiCategory(
     pageOptionsDto: SearchPostDto
   ): Promise<Post[]> {
+    const { startId, maxResults, searchWord } = pageOptionsDto;
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -275,14 +276,14 @@ export class PostRepository implements IPostRepository {
       ],
       where: {
         categoryId: In([
-          Category.typeTo("game"),
+          Category.typeTo("game"), // TODO: transform 으로 수정
           Category.typeTo("trip"),
           Category.typeTo("love"),
         ]),
-        title: Like(`%${pageOptionsDto.searchWord}%`),
+        title: Like(`%${searchWord}%`),
+        id: LessThan(startId),
       },
-      take: pageOptionsDto.maxResults + 1,
-      skip: pageOptionsDto.skip,
+      take: maxResults,
       order: { id: "DESC" },
     });
     return result;

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -289,8 +289,8 @@ export class PostRepository implements IPostRepository {
     return result;
   }
 
-  // 인기글 검색
-  public async searchTrend(pageOptionsDto: GetTrendDto): Promise<Post[]> {
+  // 인기글 조회
+  public async findAllTrends(pageOptionsDto: GetTrendDto): Promise<Post[]> {
     const { startId, maxResults } = pageOptionsDto;
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -109,6 +109,7 @@ export class PostRepository implements IPostRepository {
     categoryId: number,
     mbti: string
   ): Promise<Post[]> {
+    const { startId, maxResults } = pageOptionsDto;
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -129,9 +130,8 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: { categoryId, userMbti: mbti },
-      take: pageOptionsDto.maxResults + 1,
-      skip: pageOptionsDto.skip,
+      where: { categoryId, userMbti: mbti, id: LessThan(startId) },
+      take: maxResults,
       order: { id: "DESC" },
     });
     return result;

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -180,6 +180,7 @@ export class PostRepository implements IPostRepository {
     pageOptionsDto: SearchPostDto,
     categoryId: number
   ): Promise<Post[]> {
+    const { startId, maxResults, searchWord } = pageOptionsDto;
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -200,9 +201,12 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: { categoryId, title: Like(`%${pageOptionsDto.searchWord}%`) },
-      take: pageOptionsDto.maxResults + 1,
-      skip: pageOptionsDto.skip,
+      where: {
+        categoryId,
+        title: Like(`%${searchWord}%`),
+        id: LessThan(startId),
+      },
+      take: maxResults,
       order: { id: "DESC" },
     });
     return result;

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -217,6 +217,7 @@ export class PostRepository implements IPostRepository {
     categoryId: number,
     mbti: string
   ): Promise<Post[]> {
+    const { startId, maxResults, searchWord } = pageOptionsDto;
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -240,10 +241,10 @@ export class PostRepository implements IPostRepository {
       where: {
         categoryId,
         userMbti: mbti,
-        title: Like(`%${pageOptionsDto.searchWord}%`),
+        title: Like(`%${searchWord}%`),
+        id: LessThan(startId),
       },
-      take: pageOptionsDto.maxResults + 1,
-      skip: pageOptionsDto.skip,
+      take: maxResults,
       order: { id: "DESC" },
     });
     return result;

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -1,5 +1,5 @@
 import { inject, injectable } from "inversify";
-import { In, Like } from "typeorm";
+import { In, LessThan, LessThanOrEqual, Like, MoreThan } from "typeorm";
 import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
 import { TYPES } from "../../core/types.core";
 import { IDatabaseService } from "../../core/database/interfaces/IDatabase.service";
@@ -77,8 +77,9 @@ export class PostRepository implements IPostRepository {
     pageOptionsDto: GetAllPostDto,
     categoryId: number
   ): Promise<Post[]> {
+    const { startId, maxResults } = pageOptionsDto;
     const repository = await this._database.getRepository(Post);
-    const result = await repository.find({
+    return await repository.find({
       select: [
         "id",
         "categoryId",
@@ -97,12 +98,10 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: { categoryId },
-      take: pageOptionsDto.maxResults + 1,
-      skip: pageOptionsDto.skip,
+      where: { categoryId, id: LessThan(startId) },
+      take: maxResults,
       order: { id: "DESC" },
     });
-    return result;
   }
 
   public async findAllPostsWithMbti(

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -291,6 +291,7 @@ export class PostRepository implements IPostRepository {
 
   // 인기글 검색
   public async searchTrend(pageOptionsDto: GetTrendDto): Promise<Post[]> {
+    const { startId, maxResults } = pageOptionsDto;
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -312,9 +313,8 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: { isTrend: true },
-      take: pageOptionsDto.maxResults + 1,
-      skip: pageOptionsDto.skip,
+      where: { isTrend: true, id: LessThan(startId) },
+      take: maxResults,
       order: { id: "DESC" },
     });
     return result;

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -249,7 +249,7 @@ export class PostService implements IPostService {
     this._log(`getTrends start`);
 
     let postArray;
-    postArray = await this._postRepository.searchTrend(pageOptionsDto);
+    postArray = await this._postRepository.findAllTrends(pageOptionsDto);
 
     // 배열 마지막 id를 nextId에 할당
     const nextId = postArray[postArray.length - 1].id;

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -384,14 +384,10 @@ export class PostService implements IPostService {
       }
     }
 
-    let nextId = null;
-    if (postArray.length === pageOptionsDto.maxResults + 1) {
-      nextId = postArray[postArray.length - 1].id;
-      postArray.pop();
-    }
-    let itemsPerPage = postArray.length;
+    // 배열 마지막 id를 nextId에 할당
+    const nextId = postArray[postArray.length - 1].id;
 
-    const pageInfoDto = new PageInfiniteScrollInfoDto(itemsPerPage, nextId);
+    const pageInfoDto = new PageInfiniteScrollInfoDto(postArray.length, nextId);
 
     return new PageResponseDto(
       pageInfoDto,

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -273,6 +273,8 @@ export class PostService implements IPostService {
     this._log(`getAll start`);
     this._log(`check category name ${pageOptionsDto.category}`);
 
+    // startId에 대한 처리 필요 (1 이하일 경우, 처리)
+
     const category = await this._categoryRepository.findOneByName(
       pageOptionsDto.category
     );
@@ -298,14 +300,10 @@ export class PostService implements IPostService {
       );
     }
 
-    let nextId = null;
-    if (postArray.length === pageOptionsDto.maxResults + 1) {
-      nextId = postArray[postArray.length - 1].id;
-      postArray.pop();
-    }
-    let itemsPerPage = postArray.length;
+    // 배열 마지막 id를 nextId에 할당
+    const nextId = postArray[postArray.length - 1].id;
 
-    const pageInfoDto = new PageInfiniteScrollInfoDto(itemsPerPage, nextId);
+    const pageInfoDto = new PageInfiniteScrollInfoDto(postArray.length, nextId);
 
     return new PageResponseDto(
       pageInfoDto,

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -251,14 +251,10 @@ export class PostService implements IPostService {
     let postArray;
     postArray = await this._postRepository.searchTrend(pageOptionsDto);
 
-    let nextId = null;
-    if (postArray.length === pageOptionsDto.maxResults + 1) {
-      nextId = postArray[postArray.length - 1].id;
-      postArray.pop();
-    }
-    let itemsPerPage = postArray.length;
+    // 배열 마지막 id를 nextId에 할당
+    const nextId = postArray[postArray.length - 1].id;
 
-    const pageInfoDto = new PageInfiniteScrollInfoDto(itemsPerPage, nextId);
+    const pageInfoDto = new PageInfiniteScrollInfoDto(postArray.length, nextId);
 
     return new PageResponseDto(
       pageInfoDto,


### PR DESCRIPTION
## 개요
post pagination이 무한스크롤 방식인데, skip을 사용하고 있었음

## 작업사항
- skip 대신 nextId보다 작은 범위 내에서 검색하도록 where절 수정
- nextId 구하는 로직 변경
- post.dto 에서 skip 제거

## 변경로직

### 변경전
<img width="438" alt="스크린샷 2022-08-13 오후 1 14 16" src="https://user-images.githubusercontent.com/37575974/184468035-1fe31ff2-7a8a-47df-9e12-d72b41436b15.png">

### 변경후
<img width="449" alt="스크린샷 2022-08-13 오후 1 14 58" src="https://user-images.githubusercontent.com/37575974/184468048-423169af-b5ed-4742-9475-5521a31b315e.png">

## 기타
