### PR TITLE
Update: post pagination where 동적으로 처리

### DIFF
--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -110,7 +110,7 @@ export class PostController {
   }
 
   // 게시글 상세 조회
-  @httpGet("/:id", TYPES.ValidateAccessTokenMiddleware, paramsValidator(IdDto))
+  @httpGet("/:id", TYPES.CheckLoginStatusMiddleware, paramsValidator(IdDto))
   public async getDetailPost(
     @requestParam() param: IdDto,
     req: Request,

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -110,7 +110,7 @@ export class PostController {
   }
 
   // 게시글 상세 조회
-  @httpGet("/:id", TYPES.CheckLoginStatusMiddleware, paramsValidator(IdDto))
+  @httpGet("/:id", TYPES.ValidateAccessTokenMiddleware, paramsValidator(IdDto))
   public async getDetailPost(
     @requestParam() param: IdDto,
     req: Request,

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -340,6 +340,17 @@ export class PostRepository implements IPostRepository {
   // 인기글 조회
   public async findAllTrends(pageOptionsDto: GetTrendDto): Promise<Post[]> {
     const { startId, maxResults } = pageOptionsDto;
+    let whereCondition;
+    if (startId > 1) {
+      whereCondition = {
+        isTrend: true,
+        id: LessThan(startId),
+      };
+    } else {
+      whereCondition = {
+        isTrend: true,
+      };
+    }
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -361,7 +372,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: { isTrend: true, id: LessThan(startId) },
+      where: whereCondition,
       take: maxResults,
       order: { id: "DESC" },
     });

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -200,6 +200,16 @@ export class PostRepository implements IPostRepository {
     categoryId: number
   ): Promise<Post[]> {
     const { startId, maxResults, searchWord } = pageOptionsDto;
+    let whereCondition;
+    if (startId > 1) {
+      whereCondition = {
+        categoryId,
+        title: Like(`%${searchWord}%`),
+        id: LessThan(startId),
+      };
+    } else {
+      whereCondition = { categoryId, title: Like(`%${searchWord}%`) };
+    }
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -220,11 +230,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: {
-        categoryId,
-        title: Like(`%${searchWord}%`),
-        id: LessThan(startId),
-      },
+      where: whereCondition,
       take: maxResults,
       order: { id: "DESC" },
     });

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -78,6 +78,15 @@ export class PostRepository implements IPostRepository {
     categoryId: number
   ): Promise<Post[]> {
     const { startId, maxResults } = pageOptionsDto;
+    let whereCondition;
+    if (startId > 1) {
+      whereCondition = {
+        categoryId,
+        id: LessThan(startId),
+      };
+    } else {
+      whereCondition = { categoryId };
+    }
     const repository = await this._database.getRepository(Post);
     return await repository.find({
       select: [
@@ -98,7 +107,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: { categoryId, id: LessThan(startId) },
+      where: whereCondition,
       take: maxResults,
       order: { id: "DESC" },
     });

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -119,6 +119,16 @@ export class PostRepository implements IPostRepository {
     mbti: string
   ): Promise<Post[]> {
     const { startId, maxResults } = pageOptionsDto;
+    let whereCondition;
+    if (startId > 1) {
+      whereCondition = {
+        categoryId,
+        userMbti: mbti,
+        id: LessThan(startId),
+      };
+    } else {
+      whereCondition = { categoryId, userMbti: mbti };
+    }
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -139,7 +149,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: { categoryId, userMbti: mbti, id: LessThan(startId) },
+      where: whereCondition,
       take: maxResults,
       order: { id: "DESC" },
     });

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -243,6 +243,21 @@ export class PostRepository implements IPostRepository {
     mbti: string
   ): Promise<Post[]> {
     const { startId, maxResults, searchWord } = pageOptionsDto;
+    let whereCondition;
+    if (startId > 1) {
+      whereCondition = {
+        categoryId,
+        userMbti: mbti,
+        title: Like(`%${searchWord}%`),
+        id: LessThan(startId),
+      };
+    } else {
+      whereCondition = {
+        categoryId,
+        userMbti: mbti,
+        title: Like(`%${searchWord}%`),
+      };
+    }
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -263,12 +278,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: {
-        categoryId,
-        userMbti: mbti,
-        title: Like(`%${searchWord}%`),
-        id: LessThan(startId),
-      },
+      where: whereCondition,
       take: maxResults,
       order: { id: "DESC" },
     });

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -289,6 +289,27 @@ export class PostRepository implements IPostRepository {
     pageOptionsDto: SearchPostDto
   ): Promise<Post[]> {
     const { startId, maxResults, searchWord } = pageOptionsDto;
+    let whereCondition;
+    if (startId > 1) {
+      whereCondition = {
+        categoryId: In([
+          Category.typeTo("game"), // TODO: transform 으로 수정
+          Category.typeTo("trip"),
+          Category.typeTo("love"),
+        ]),
+        title: Like(`%${searchWord}%`),
+        id: LessThan(startId),
+      };
+    } else {
+      whereCondition = {
+        categoryId: In([
+          Category.typeTo("game"), // TODO: transform 으로 수정
+          Category.typeTo("trip"),
+          Category.typeTo("love"),
+        ]),
+        title: Like(`%${searchWord}%`),
+      };
+    }
     const repository = await this._database.getRepository(Post);
     const result = await repository.find({
       select: [
@@ -309,15 +330,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: {
-        categoryId: In([
-          Category.typeTo("game"), // TODO: transform 으로 수정
-          Category.typeTo("trip"),
-          Category.typeTo("love"),
-        ]),
-        title: Like(`%${searchWord}%`),
-        id: LessThan(startId),
-      },
+      where: whereCondition,
       take: maxResults,
       order: { id: "DESC" },
     });


### PR DESCRIPTION
## 개요
startId가 1 이하일 경우 가져올 수 있는 데이터가 없음

## 작업사항
- startId가 1 이하일 경우에는 전체 데이터에서 가져오도록 수정
- 게시글 상세 조회 잘못된 미들웨어 수정

## 변경로직

### 변경전
<img width="355" alt="스크린샷 2022-08-13 오후 1 58 08" src="https://user-images.githubusercontent.com/37575974/184469168-2679965e-b7ab-469e-951b-fe57dbc9f612.png">

### 변경후
<img width="272" alt="스크린샷 2022-08-13 오후 1 58 34" src="https://user-images.githubusercontent.com/37575974/184469180-8a6548e5-181c-4bc1-90bd-0a26f090d98e.png">

## 기타
조건문이 마음에 들진 않지만.. 추후 리펙토링에서 간단하게 바꿀 수 있는건 바꾸자..