### PR TITLE
Fix: create-base-category 마이그레이션 동기화 문제

### DIFF
--- a/src/migrations/1660457303391-create-base-category.ts
+++ b/src/migrations/1660457303391-create-base-category.ts
@@ -22,10 +22,10 @@ export class createBaseCategory1660457303391 implements MigrationInterface {
     });
 
     // 2. BASE_CATEGORIES 배열 돌면서 없는 low INSERT
-    BASE_CATEGORIES.forEach(async (e) => {
-      const foundCategory = categories.find((c) => c.name === e);
-      if (!foundCategory) await repository.insert({ name: e });
-    });
+    for (const categoryName of BASE_CATEGORIES) {
+      const foundCategory = categories.find((c) => c.name === categoryName);
+      if (!foundCategory) await repository.insert({ name: categoryName });
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {}


### PR DESCRIPTION
## 개요
![image](https://user-images.githubusercontent.com/105474635/184536790-0f8e8af8-cd59-45ea-886e-6bee8c19489c.png)
마이그레이션 `create-base-category` 실행 도중, INSERT가 끝나지 않았는데 마이그레이션 커밋이 완료된 상태.
덕분에 Pool이 닫힌 상태에서 추가적인 비동기 쿼리가 날아가 에러가 터지는 상황
## 작업사항
- forEach를 for of로 변경하여 해결 
- Promise.all은 순서보장이 안되는데, 카테고리 id 순서가 중요하기 때문에 속도가 느리더라도 for of사용함
## 기타
참고
[[JS] forEach 함수는 async 함수를 기다려주지 않는다](https://constructionsite.tistory.com/43)