### PR TITLE
Refactor: post create dto

### DIFF
--- a/src/modules/post/dto/create-post.dto.ts
+++ b/src/modules/post/dto/create-post.dto.ts
@@ -1,16 +1,17 @@
 import {
   IsBoolean,
-  IsInt,
+  IsEnum,
   IsNotEmpty,
   IsOptional,
   IsString,
   Length,
 } from "class-validator";
+import { CategoryName } from "../../../shared/enum.shared";
 
 export class CreatePostDto {
-  @IsInt()
+  @IsEnum(CategoryName)
   @IsNotEmpty()
-  categoryId: number;
+  category: CategoryName;
 
   @IsBoolean()
   @IsOptional()

--- a/src/modules/post/interfaces/IPost.service.ts
+++ b/src/modules/post/interfaces/IPost.service.ts
@@ -1,3 +1,4 @@
+import { CategoryName } from "../../../shared/enum.shared";
 import {
   PageInfiniteScrollInfoDto,
   PageResponseDto,
@@ -16,7 +17,7 @@ export interface IPostService {
     isSecret: boolean,
     title: string,
     content: string,
-    categoryId: number,
+    category: CategoryName,
     user: User
   ): Promise<PostResponseDto>;
   increaseReportCount(id: number): Promise<void>;

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -42,14 +42,14 @@ export class PostController {
     req: Request,
     res: Response
   ) {
-    const { categoryId, isSecret, title, content } = body;
+    const { category, isSecret, title, content } = body;
     const user = req.user as User;
 
     const data = await this._postService.create(
       isSecret,
       title,
       content,
-      categoryId,
+      category,
       user
     );
 

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -50,14 +50,15 @@ export class PostService implements IPostService {
     isSecret: boolean,
     title: string,
     content: string,
-    categoryId: number,
+    categoryName: CategoryName,
     user: User
   ): Promise<PostResponseDto> {
     this._log(`create start`);
-    const category = await this._categoryRepository.findOneById(categoryId);
+
+    const category = await this._categoryRepository.findOneByName(categoryName);
 
     if (!category || !category.isActive) {
-      throw new NotFoundException("category id error");
+      throw new NotFoundException("category name error");
     }
 
     let postType = PostType.POST;

--- a/src/swagger/paths/posts/index.yaml
+++ b/src/swagger/paths/posts/index.yaml
@@ -2,7 +2,7 @@ post:
   tags:
     - posts
   description: 게시글을 등록합니다. <br>
-    (필수) 게시글이 등록될 카테고리 아이디 <br>
+    (필수) 게시글이 등록될 카테고리 이름 <br>
     isSecret 익명 여부 default - false <br>
     (필수) post 제목 (1~30자) <br>
     (필수) post 내용
@@ -14,9 +14,9 @@ post:
         schema:
           type: object
           properties:
-            categoryId:
-              type: integer
-              example: 2
+            category:
+              type: string
+              example: trip
             isSecret:
               type: boolean
               example: false


### PR DESCRIPTION
## 개요
post create dto에서 category가 Id로 전달되는 상황, 다른 dto와의 통일성을 위해 수정해줬다.
 
## 작업사항
- `create-post-dto`에서 categoryId -> categoryName으로 수정
- 변경 사항 스웨거에 적용
