### PR TITLE
Update: post search

### DIFF
--- a/src/modules/category/entity/category.entity.ts
+++ b/src/modules/category/entity/category.entity.ts
@@ -32,6 +32,8 @@ export class Category extends BaseEntity {
         return 7;
       case "hobby":
         return 8;
+      default:
+        return 0;
     }
   }
 

--- a/src/modules/post/dto/search-post.dto.ts
+++ b/src/modules/post/dto/search-post.dto.ts
@@ -1,6 +1,18 @@
 import { Type } from "class-transformer";
-import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from "class-validator";
-import { CategoryName, PostOrder } from "../../../shared/enum.shared";
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from "class-validator";
+import {
+  CategoryName,
+  PostOrder,
+  SearchOption,
+} from "../../../shared/enum.shared";
 
 export class SearchPostDto {
   @IsEnum(CategoryName)
@@ -23,6 +35,10 @@ export class SearchPostDto {
   @IsEnum(PostOrder)
   @IsOptional()
   order: PostOrder = PostOrder.CREATED_AT;
+
+  @IsEnum(SearchOption)
+  @IsNotEmpty()
+  searchOption: SearchOption;
 
   @IsString()
   @IsOptional()

--- a/src/modules/post/interfaces/IPost.repository.ts
+++ b/src/modules/post/interfaces/IPost.repository.ts
@@ -1,3 +1,4 @@
+import { CategoryName } from "../../../shared/enum.shared";
 import {
   GetMyPostsDto,
   GetAllPostDto,
@@ -32,6 +33,10 @@ export interface IPostRepository {
   searchInMbtiCategory(
     pageOptionsDto: SearchPostDto,
     mbti: string
+  ): Promise<Post[]>;
+  searchInCategory(
+    pageOptionsDto: SearchPostDto,
+    category: number
   ): Promise<Post[]>;
   findAllTrends(pageOptionsDto: GetTrendDto): Promise<Post[]>;
   searchAllWithMbti(

--- a/src/modules/post/interfaces/IPost.repository.ts
+++ b/src/modules/post/interfaces/IPost.repository.ts
@@ -38,5 +38,5 @@ export interface IPostRepository {
     pageOptionsDto: SearchPostDto,
     mbti: string
   ): Promise<Post[]>;
-  searchWithoutMbtiCategory(pageOptionsDto: SearchPostDto): Promise<Post[]>;
+  searchAllWithoutMbtiCategory(pageOptionsDto: SearchPostDto): Promise<Post[]>;
 }

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -261,7 +261,7 @@ export class PostRepository implements IPostRepository {
   }
 
   // mbti 카테고리 제외 전체 검색
-  public async searchWithoutMbtiCategory(
+  public async searchAllWithoutMbtiCategory(
     pageOptionsDto: SearchPostDto
   ): Promise<Post[]> {
     const { startId, maxResults, searchWord, searchOption } = pageOptionsDto;

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -12,13 +12,31 @@ import {
   GetAllPostDto,
   SearchPostDto,
 } from "./dto";
-import { CategoryName } from "../../shared/enum.shared";
+import { SearchOption } from "../../shared/enum.shared";
 
 @injectable()
 export class PostRepository implements IPostRepository {
   constructor(
     @inject(TYPES.IDatabaseService) private readonly _database: IDatabaseService
   ) {}
+
+  private _searchOption(
+    whereCondition: any,
+    option: SearchOption,
+    searchWord: string
+  ) {
+    switch (option) {
+      case SearchOption.TITLE:
+        return { ...whereCondition, title: Like(`%${searchWord}%`) };
+      case SearchOption.CONTENT:
+        return { ...whereCondition, content: Like(`%${searchWord}%`) };
+      case SearchOption.ALL:
+        return [
+          { ...whereCondition, title: Like(`%${searchWord}%`) },
+          { ...whereCondition, content: Like(`%${searchWord}%`) },
+        ];
+    }
+  }
 
   public async create(postEntity: Post) {
     const repository = await this._database.getRepository(Post);
@@ -248,18 +266,16 @@ export class PostRepository implements IPostRepository {
   public async searchWithoutMbtiCategory(
     pageOptionsDto: SearchPostDto
   ): Promise<Post[]> {
-    const { startId, maxResults, searchWord } = pageOptionsDto;
+    const { startId, maxResults, searchWord, searchOption } = pageOptionsDto;
     let whereCondition;
     if (startId > 1) {
       whereCondition = {
         categoryId: Not(In([Category.typeTo("mbti")])),
-        title: Like(`%${searchWord}%`),
         id: LessThan(startId),
       };
     } else {
       whereCondition = {
         categoryId: Not(In([Category.typeTo("mbti")])),
-        title: Like(`%${searchWord}%`),
       };
     }
     const repository = await this._database.getRepository(Post);
@@ -282,7 +298,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: whereCondition,
+      where: this._searchOption(whereCondition, searchOption, searchWord),
       take: maxResults,
       order: { id: "DESC" },
     });

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -219,20 +219,18 @@ export class PostRepository implements IPostRepository {
     pageOptionsDto: SearchPostDto,
     mbti: string
   ): Promise<Post[]> {
-    const { startId, maxResults, searchWord } = pageOptionsDto;
+    const { startId, maxResults, searchWord, searchOption } = pageOptionsDto;
     let whereCondition;
     if (startId > 1) {
       whereCondition = {
         categoryId: Category.typeTo("mbti"),
         userMbti: mbti,
-        title: Like(`%${searchWord}%`),
         id: LessThan(startId),
       };
     } else {
       whereCondition = {
         categoryId: Category.typeTo("mbti"),
         userMbti: mbti,
-        title: Like(`%${searchWord}%`),
       };
     }
     const repository = await this._database.getRepository(Post);
@@ -255,7 +253,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: whereCondition,
+      where: this._searchOption(whereCondition, searchOption, searchWord),
       take: maxResults,
       order: { id: "DESC" },
     });

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -13,6 +13,7 @@ import {
   SearchPostDto,
 } from "./dto";
 import { SearchOption } from "../../shared/enum.shared";
+import { CategoryName } from "aws-sdk/clients/support";
 
 @injectable()
 export class PostRepository implements IPostRepository {
@@ -231,6 +232,50 @@ export class PostRepository implements IPostRepository {
       whereCondition = {
         categoryId: Category.typeTo("mbti"),
         userMbti: mbti,
+      };
+    }
+    const repository = await this._database.getRepository(Post);
+    const result = await repository.find({
+      select: [
+        "id",
+        "categoryId",
+        "type",
+        "isActive",
+        "userId",
+        "userNickname",
+        "userMbti",
+        "isSecret",
+        "title",
+        "content",
+        "viewCount",
+        "commentCount",
+        "likesCount",
+        "reportCount",
+        "createdAt",
+        "updatedAt",
+      ],
+      where: this._searchOption(whereCondition, searchOption, searchWord),
+      take: maxResults,
+      order: { id: "DESC" },
+    });
+    return result;
+  }
+
+  // 특정 카테고리에서 검색 (mbti 카테고리 제외)
+  public async searchInCategory(
+    pageOptionsDto: SearchPostDto,
+    categoryId: number
+  ): Promise<Post[]> {
+    const { startId, maxResults, searchWord, searchOption } = pageOptionsDto;
+    let whereCondition;
+    if (startId > 1) {
+      whereCondition = {
+        categoryId,
+        id: LessThan(startId),
+      };
+    } else {
+      whereCondition = {
+        categoryId,
       };
     }
     const repository = await this._database.getRepository(Post);

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -397,9 +397,9 @@ export class PostRepository implements IPostRepository {
   ): Promise<Post[]> {
     const repository = await this._database.getRepository(Post);
     const { startId, maxResults, searchWord, searchOption } = pageOptionsDto;
-    let whereCondition;
+    let whereConditions;
     if (startId > 1) {
-      whereCondition = [
+      whereConditions = [
         {
           categoryId: Not(In([Category.typeTo("mbti")])),
           id: LessThan(startId),
@@ -411,7 +411,7 @@ export class PostRepository implements IPostRepository {
         },
       ];
     } else {
-      whereCondition = [
+      whereConditions = [
         {
           categoryId: Not(In([Category.typeTo("mbti")])),
         },
@@ -423,8 +423,8 @@ export class PostRepository implements IPostRepository {
     }
 
     let where = [];
-    for (let x of whereCondition) {
-      where.push(this._searchOption(x, searchOption, searchWord));
+    for (let whereCondition of whereConditions) {
+      where.push(this._searchOption(whereCondition, searchOption, searchWord));
     }
     const result = await repository.find({
       select: [

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -446,7 +446,7 @@ export class PostRepository implements IPostRepository {
         "createdAt",
         "updatedAt",
       ],
-      where: where[0],
+      where,
       take: maxResults,
       order: { id: "DESC" },
     });

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -383,6 +383,8 @@ export class PostService implements IPostService {
       }
     }
 
+    // TODO: 아무것도 검색되지 않았을 때 예외처리 해주기
+
     // 배열 마지막 id를 nextId에 할당
     const nextId = postArray[postArray.length - 1].id;
 

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -383,10 +383,13 @@ export class PostService implements IPostService {
       }
     }
 
-    // TODO: 아무것도 검색되지 않았을 때 예외처리 해주기
-
-    // 배열 마지막 id를 nextId에 할당
-    const nextId = postArray[postArray.length - 1].id;
+    let nextId;
+    if (postArray.length === 0) {
+      nextId = null;
+    } else {
+      // 배열 마지막 id를 nextId에 할당
+      nextId = postArray[postArray.length - 1].id;
+    }
 
     const pageInfoDto = new PageInfiniteScrollInfoDto(postArray.length, nextId);
 

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -14,6 +14,7 @@ import {
   PageInfoDto,
 } from "../../shared/page";
 import { Logger } from "../../shared/utils/logger.util";
+import { Category } from "../category/entity/category.entity";
 import { ICategoryRepository } from "../category/interfaces/ICategory.repository";
 import { INotificationService } from "../notifications/interfaces/INotification.service";
 import { User } from "../user/entity/user.entity";
@@ -345,7 +346,7 @@ export class PostService implements IPostService {
     if (!pageOptionsDto.category) {
       // 로그인 하지 않은 경우 (mbti카테고리 제외 전체 검색)
       if (!user) {
-        postArray = await this._postRepository.searchWithoutMbtiCategory(
+        postArray = await this._postRepository.searchAllWithoutMbtiCategory(
           pageOptionsDto
         );
       }
@@ -361,8 +362,9 @@ export class PostService implements IPostService {
     else {
       // 카테고리가 mbti가 아닌 경우
       if (pageOptionsDto.category !== CategoryName.MBTI) {
-        postArray = await this._postRepository.searchWithoutMbtiCategory(
-          pageOptionsDto
+        postArray = await this._postRepository.searchInCategory(
+          pageOptionsDto,
+          Category.typeTo(pageOptionsDto.category)
         );
       }
       // 카테고리가 mbti인 경우

--- a/src/shared/enum.shared.ts
+++ b/src/shared/enum.shared.ts
@@ -21,6 +21,12 @@ export enum PostType {
   NOTICE = "notice",
 }
 
+export enum SearchOption {
+  TITLE = "title",
+  CONTENT = "content",
+  ALL = "all",
+}
+
 export enum CategoryName {
   MBTI = "mbti",
   LOVE = "love",


### PR DESCRIPTION
## 개요
검색 옵션으로 값을 찾을 때 제목만 기준으로 찾고 있었음

## 작업사항
- searchOption enum추가
- 검색 옵션에 맞게 whereOption을 만들어주는 함수 작성
- 카테고리 선택 후 검색하는 함수 작성

## 변경로직

### 변경전
제목만 기준으로 쿼리문을 작성함
<img width="300" alt="스크린샷 2022-08-17 오후 2 54 41" src="https://user-images.githubusercontent.com/37575974/185044875-47e7277c-8ef3-4a90-94c4-9369643dae91.png">


### 변경후
검색 옵션에 따라 동적으로 처리 가능한 함수 작성
<img width="509" alt="스크린샷 2022-08-17 오후 2 54 19" src="https://user-images.githubusercontent.com/37575974/185044825-7c8fa4bf-f5c8-4a7a-b7f3-f290145e8bb9.png">

아래와 같이 사용하도록 변경
<img width="501" alt="스크린샷 2022-08-17 오후 2 56 05" src="https://user-images.githubusercontent.com/37575974/185045084-d3a62b04-c99e-4119-8dba-717fcdeb2e28.png">
