### PR TITLE
!HOTFIX: 대댓글 조회 버그 

### DIFF
--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -208,7 +208,10 @@ export class CommentService implements ICommentService {
         `there are no replies to parent comment id ${pageOptionsDto.parentId}`
       );
 
-    const nextId = replyArray[replyArray.length - 1].id;
+    // replyArray길이가 maxResults보다 작다면 nextId는 null, 아니라면 마지막 idx의 id 할당
+    let nextId: number | null;
+    if (replyArray.length < pageOptionsDto.maxResults) nextId = null;
+    else nextId = replyArray[replyArray.length - 1].id;
 
     // 응답 DTO로 변환후 리턴
     const pageInfoDto = new PageInfiniteScrollInfoDto(

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -202,8 +202,12 @@ export class CommentService implements ICommentService {
     const replyArray = await this._commentRepository.findAllReplies(
       pageOptionsDto
     );
+    // 아무런 대댓글 없으면 NotFoundException
+    if (replyArray.length === 0)
+      throw new NotFoundException(
+        `there are no replies to parent comment id ${pageOptionsDto.parentId}`
+      );
 
-    // 배열 마지막 id를 nextId에 할당
     const nextId = replyArray[replyArray.length - 1].id;
 
     // 응답 DTO로 변환후 리턴

--- a/src/swagger/responses/comments/replies.get.yaml
+++ b/src/swagger/responses/comments/replies.get.yaml
@@ -63,7 +63,9 @@
                   example: 3
 
 "404":
-  description: 존재하지 않는 (삭제된) 게시글
+  description: 존재하지 않는 (삭제된) 게시글 <br>
+    또는 존재하지 않는 부모 댓글 <br>
+    또는 부모 댓글에 대댓글이 존재하지 않음
   content:
     application/json:
       schema:
@@ -71,4 +73,7 @@
         properties:
           message:
             type: string
-            example: not exists post
+            example:
+              ex1: not exists post
+              ex2: not exists comment
+              ex3: there are no replies to parent comment id 3


### PR DESCRIPTION
## 개요
comment 테이블이 비어있는 상태에서 대댓글 조회시 에러가 터지는 상황
## 작업사항
- 버그수정 : 빈 배열일시 404 에러
- nextId 로직 수정
  - 만약 요청 maxResults가 10인데, 조회된 대댓글 결과가 3개라면, nextId가 null이어야 한다.
  - 하지만 조회된 마지막 대댓글 id를 응답해서, 대댓글 결과 < maxResults라면, nextId 에 null 할당으로 수정
- 위 두사항에 대한 대댓글 조회 swagger 반영
## 변경로직
### 변경전
```ts
    const replyArray = await this._commentRepository.findAllReplies(
      pageOptionsDto
    );
    const nextId = replyArray[replyArray.length - 1].id; // replyArray가 빈배열[] 라면 Error !!

```
### 변경후
```ts
    const replyArray = await this._commentRepository.findAllReplies(
      pageOptionsDto
    );

    // 아무런 대댓글 없으면 NotFoundException
    if (replyArray.length === 0)
      throw new NotFoundException(
        `there are no replies to parent comment id ${pageOptionsDto.parentId}`
      );

  
    // replyArray길이가 maxResults보다 작다면 nextId는 null, 아니라면 마지막 idx의 id 할당
    let nextId: number | null;
    if (replyArray.length < pageOptionsDto.maxResults) nextId = null;
    else nextId = replyArray[replyArray.length - 1].id;
```

## 기타
Related to: #166