### PR TITLE
Fix: 댓글 조회시 totalCount 값 불일치 수정

### DIFF
--- a/src/modules/comment/comment.repository.ts
+++ b/src/modules/comment/comment.repository.ts
@@ -29,7 +29,7 @@ export class CommentRepository implements ICommentRepository {
 
   public async findAllComments(
     pageOptionsDto: GetAllCommentDto
-  ): Promise<Comment[]> {
+  ): Promise<[Comment[], number]> {
     const repository = await this._database.getRepository(Comment);
     const queryBuilder = repository
       .createQueryBuilder("comment")
@@ -59,7 +59,7 @@ export class CommentRepository implements ICommentRepository {
       queryBuilder.addOrderBy(`comment.${pageOptionsDto.order}`, "ASC");
     }
 
-    return queryBuilder.getMany();
+    return queryBuilder.getManyAndCount();
   }
 
   public async findAllReplies(

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -167,13 +167,12 @@ export class CommentService implements ICommentService {
     if (!foundPost || !foundPost.isActive)
       throw new NotFoundException("not exists post");
 
-    const commentArray = await this._commentRepository.findAllComments(
-      pageOptionsDto
-    );
+    const [commentArray, totalCount] =
+      await this._commentRepository.findAllComments(pageOptionsDto);
 
     // 페이지 정보
     const pageInfoDto = new PageInfoDto(
-      foundPost.commentCount,
+      totalCount,
       commentArray.length,
       page,
       maxResults

--- a/src/modules/comment/interfaces/IComment.repository.ts
+++ b/src/modules/comment/interfaces/IComment.repository.ts
@@ -4,7 +4,9 @@ import { Comment } from "../entity/comment.entity";
 export interface ICommentRepository {
   createComment(commentEntity: Comment): Promise<Comment>;
   findOneById(id: number): Promise<Comment | null>;
-  findAllComments(pageOptionsDto: GetAllCommentDto): Promise<Comment[]>;
+  findAllComments(
+    pageOptionsDto: GetAllCommentDto
+  ): Promise<[Comment[], number]>;
   findAllReplies(pageOptionsDto: GetAllRepliesDto): Promise<Comment[]>;
   findAllByUser(
     pageOptionsDto: GetAllByUserDto,


### PR DESCRIPTION
## 개요
- 게시글 댓글 조회시 `items`는 비어있는데, `totalCount`를 post 테이블의 `commentCount` 컬럼으로 설정해서 값이 불일치하는 상황
```json
{
    "pageInfo": {
        "totalCount": 11,
        "itemsPerPage": 0,
        "currentPage": 1,
        "totalPage": 1
    },
    "items": []
}
```
## 작업사항
- `getManyAndCount` 성능의 이유로 `getMany`로 바꾸었으나 다시 `getManyAndCount`로 수정
## 변경로직

### 변경전
```ts
    const commentArray = await this._commentRepository.findAllComments(
      pageOptionsDto
    );

    // 페이지 정보
    const pageInfoDto = new PageInfoDto(
      foundPost.commentCount,
      commentArray.length,
      page,
      maxResults
```
### 변경후
```ts
    const [commentArray, totalCount] =
      await this._commentRepository.findAllComments(pageOptionsDto);

    // 페이지 정보
    const pageInfoDto = new PageInfoDto(
      totalCount,
      commentArray.length,
      page,
      maxResults

```