### PR TITLE
!HOTFIX: 게시글 조회 버그

### DIFF
--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -298,8 +298,13 @@ export class PostService implements IPostService {
       );
     }
 
-    // 배열 마지막 id를 nextId에 할당
-    const nextId = postArray[postArray.length - 1].id;
+    let nextId;
+    if (postArray.length === 0) {
+      nextId = null;
+    } else {
+      // 배열 마지막 id를 nextId에 할당
+      nextId = postArray[postArray.length - 1].id;
+    }
 
     const pageInfoDto = new PageInfiniteScrollInfoDto(postArray.length, nextId);
 

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -253,8 +253,13 @@ export class PostService implements IPostService {
     let postArray;
     postArray = await this._postRepository.findAllTrends(pageOptionsDto);
 
-    // 배열 마지막 id를 nextId에 할당
-    const nextId = postArray[postArray.length - 1].id;
+    let nextId;
+    if (postArray.length === 0) {
+      nextId = null;
+    } else {
+      // 배열 마지막 id를 nextId에 할당
+      nextId = postArray[postArray.length - 1].id;
+    }
 
     const pageInfoDto = new PageInfiniteScrollInfoDto(postArray.length, nextId);
 

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -303,8 +303,12 @@ export class PostService implements IPostService {
       );
     }
 
-    let nextId;
     if (postArray.length === 0) {
+      throw new NotFoundException(`post not found`);
+    }
+
+    let nextId: number | null;
+    if (postArray.length < pageOptionsDto.maxResults) {
       nextId = null;
     } else {
       // 배열 마지막 id를 nextId에 할당

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -253,8 +253,12 @@ export class PostService implements IPostService {
     let postArray;
     postArray = await this._postRepository.findAllTrends(pageOptionsDto);
 
-    let nextId;
     if (postArray.length === 0) {
+      throw new NotFoundException(`post not found`);
+    }
+
+    let nextId: number | null;
+    if (postArray.length < pageOptionsDto.maxResults) {
       nextId = null;
     } else {
       // 배열 마지막 id를 nextId에 할당

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -394,8 +394,12 @@ export class PostService implements IPostService {
       }
     }
 
-    let nextId;
     if (postArray.length === 0) {
+      throw new NotFoundException(`post not found`);
+    }
+
+    let nextId: number | null;
+    if (postArray.length < pageOptionsDto.maxResults) {
       nextId = null;
     } else {
       // 배열 마지막 id를 nextId에 할당

--- a/src/swagger/responses/posts/index.get.yaml
+++ b/src/swagger/responses/posts/index.get.yaml
@@ -66,3 +66,15 @@
               updatedAt:
                 type: Date | null
                 example: null
+
+"404":
+  description: 게시글이 존재하지 않음
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          message:
+            type: string
+            example:
+              ex1: post not found

--- a/src/swagger/responses/posts/search.get.yaml
+++ b/src/swagger/responses/posts/search.get.yaml
@@ -64,3 +64,15 @@
             updatedAt:
               type: Date
               example: 2022-07-21T17:32:28Z
+
+"404":
+  description: 게시글이 존재하지 않음
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          message:
+            type: string
+            example:
+              ex1: post not found

--- a/src/swagger/responses/posts/trending.get.yaml
+++ b/src/swagger/responses/posts/trending.get.yaml
@@ -66,3 +66,15 @@
               updatedAt:
                 type: Date | null
                 example: null
+
+"404":
+  description: 게시글이 존재하지 않음
+  content:
+    application/json:
+      schema:
+        type: object
+        properties:
+          message:
+            type: string
+            example:
+              ex1: post not found


### PR DESCRIPTION
## 개요
post 테이블이 비어있는 상태에서 게시글 조회시 에러가 터지는 상황

## 작업사항
- 전체 게시글 조회시 nextId 수정
- 인기글 조회시 nextId 수정
- 게시글 검색시 nextId 수정
- 404 NotFound 추가
- swagger 수정

## 변경로직

### 변경전
<img width="387" alt="스크린샷 2022-08-18 오후 11 40 14" src="https://user-images.githubusercontent.com/37575974/185423067-1016e3af-4573-4954-8b65-5ec70d1bbd1f.png">


### 변경후
<img width="449" alt="스크린샷 2022-08-18 오후 11 40 40" src="https://user-images.githubusercontent.com/37575974/185423165-623e738a-17f5-4cd2-ba9f-30bb8a90391a.png">


