### PR TITLE
Chore: package.json 마이그레이션 script 로컬에서 적용되게 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "test": "jest",
     "test:c": "jest --coverage",
     "api-docs": "swagger-cli bundle ./src/swagger/openapi.yaml --outfile src/swagger.yaml --type yaml",
-    "typeorm": "ts-node ./node_modules/typeorm/cli -d src/datasource.ts",
-    "typeorm:create": "npm run typeorm migration:create",
-    "typeorm:generate": "npm run typeorm migration:generate",
-    "typeorm:run": "npm run typeorm migration:run",
-    "typeorm:revert": "npm run typeorm migration:revert"
+    "typeorm": "ts-node ./node_modules/typeorm/cli",
+    "migration:create": "npm run typeorm migration:create",
+    "migration:generate": "npm run typeorm migration:generate -- -d src/datasource.ts",
+    "migration:up": "npm run typeorm migration:run -- -d src/datasource.ts",
+    "migration:down": "npm run typeorm migration:revert -- -d src/datasource.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "main.js",
   "scripts": {
-    "start": "npm run typeorm:run && NODE_ENV=production node dist/main.js",
-    "dev": "npm run typeorm:run && npm run api-docs && NODE_ENV=development nodemon src/main.ts",
+    "start": "npm run migration:up && NODE_ENV=production node dist/main.js",
+    "dev": "npm run migration:up && npm run api-docs && NODE_ENV=development nodemon src/main.ts",
     "build": "tsc",
     "lint": "eslint . --ext .js,.ts",
     "test": "jest",


### PR DESCRIPTION
## 개요
- package.json의 script 중 마이그레이션 명령어가 typeorm 글로벌 설치가 안되어있으면 실행하지 못하는 상황
## 작업사항
* global typeorm 설치 없이 가능하게 수정함
