### PR TITLE
Refactor: 삭제 메소드 이름 통합

### DIFF
--- a/src/modules/bookmark/bookmark.controller.ts
+++ b/src/modules/bookmark/bookmark.controller.ts
@@ -45,7 +45,7 @@ export class BookmarkController {
     TYPES.ValidateAccessTokenMiddleware,
     paramsValidator(IdDto)
   )
-  public async delete(
+  public async remove(
     @requestParam() param: IdDto,
     req: Request,
     res: Response
@@ -53,7 +53,7 @@ export class BookmarkController {
     const user = req.user as User;
     const { id } = param;
 
-    await this._bookmarkService.delete(user, id);
+    await this._bookmarkService.remove(user, id);
 
     return res.status(204).json();
   }

--- a/src/modules/bookmark/bookmark.service.ts
+++ b/src/modules/bookmark/bookmark.service.ts
@@ -85,8 +85,8 @@ export class BookmarkService implements IBookmarkService {
     );
   }
 
-  public async delete(user: User, id: number): Promise<void> {
-    this._log(`delete start`);
+  public async remove(user: User, id: number): Promise<void> {
+    this._log(`remove start`);
     // 북마크 검증
     const bookmark = await this._bookmarkRepository.findOneById(id);
     if (!bookmark || !bookmark.isActive)

--- a/src/modules/bookmark/interfaces/IBookmark.service.ts
+++ b/src/modules/bookmark/interfaces/IBookmark.service.ts
@@ -10,5 +10,5 @@ export interface IBookmarkService {
     user: User,
     pageOptionsDto: PageOptionsDto
   ): Promise<PageResponseDto<PageInfoDto, BookmarkPostResponseDto>>;
-  delete(user: User, id: number): Promise<void>;
+  remove(user: User, id: number): Promise<void>;
 }

--- a/src/modules/comment/comment.controller.ts
+++ b/src/modules/comment/comment.controller.ts
@@ -140,7 +140,7 @@ export class CommentController {
     TYPES.ValidateAccessTokenMiddleware,
     paramsValidator(IdDto)
   )
-  public async delete(
+  public async remove(
     @requestParam() param: IdDto,
     req: Request,
     res: Response
@@ -148,7 +148,7 @@ export class CommentController {
     const user = req.user as User;
     const { id } = param;
 
-    await this._commentService.delete(user, id);
+    await this._commentService.remove(user, id);
 
     return res.status(204).json();
   }

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -305,7 +305,7 @@ export class CommentService implements ICommentService {
     return new CommentResponseDto(updatedComment, user);
   }
 
-  public async delete(user: User, id: number): Promise<void> {
+  public async remove(user: User, id: number): Promise<void> {
     this._log(`delete start`);
     // 댓글 존재하는지 확인
     const comment = await this._commentRepository.findOneById(id);

--- a/src/modules/comment/comment.service.ts
+++ b/src/modules/comment/comment.service.ts
@@ -306,7 +306,7 @@ export class CommentService implements ICommentService {
   }
 
   public async remove(user: User, id: number): Promise<void> {
-    this._log(`delete start`);
+    this._log(`remove start`);
     // 댓글 존재하는지 확인
     const comment = await this._commentRepository.findOneById(id);
     this._logger.trace(`[CommentService] check exists comment id ${id}`);

--- a/src/modules/comment/interfaces/IComment.service.ts
+++ b/src/modules/comment/interfaces/IComment.service.ts
@@ -44,6 +44,6 @@ export interface ICommentService {
   increaseLikeCount(id: number): Promise<void>;
   decreaseLikeCount(id: number): Promise<void>;
   update(user: User, id: number, content: string): Promise<CommentResponseDto>;
-  delete(user: User, id: number): Promise<void>;
+  remove(user: User, id: number): Promise<void>;
   isValid(id: number): Promise<boolean>;
 }

--- a/src/modules/like/interfaces/ILike.service.ts
+++ b/src/modules/like/interfaces/ILike.service.ts
@@ -2,11 +2,7 @@ import { User } from "../../user/entity/user.entity";
 import { LikeResponseDto } from "../dto/like-response.dto";
 
 export interface ILikeService {
-  createLike(
-    type: string,
-    targetId: number,
-    user: User
-  ): Promise<LikeResponseDto>;
+  create(type: string, targetId: number, user: User): Promise<LikeResponseDto>;
   //   getStatus(type: number, targetId: number, user: User): Promise<boolean>;
-  deleteLike(type: string, targetId: number, user: User): Promise<void>;
+  remove(type: string, targetId: number, user: User): Promise<void>;
 }

--- a/src/modules/like/like.controller.ts
+++ b/src/modules/like/like.controller.ts
@@ -35,7 +35,7 @@ export class LikeController {
     const { type, targetId } = body;
     const user = req.user as User;
 
-    const data = await this._likeService.createLike(type, targetId, user);
+    const data = await this._likeService.create(type, targetId, user);
 
     return res.status(201).json(data);
   }
@@ -46,7 +46,7 @@ export class LikeController {
     TYPES.ValidateAccessTokenMiddleware,
     queryValidator(DeleteLikeDto)
   )
-  public async deleteLike(
+  public async Ldeleteike(
     @queryParam() query: DeleteLikeDto,
     req: Request,
     res: Response
@@ -54,7 +54,7 @@ export class LikeController {
     const { type, targetId } = query;
     const user = req.user as User;
 
-    await this._likeService.deleteLike(type, targetId, user);
+    await this._likeService.remove(type, targetId, user);
 
     return res.status(204).json();
   }

--- a/src/modules/like/like.service.ts
+++ b/src/modules/like/like.service.ts
@@ -81,12 +81,12 @@ export class LikeService implements ILikeService {
     return likeTarget;
   }
 
-  public async createLike(
+  public async create(
     type: string,
     targetId: number,
     user: User
   ): Promise<LikeResponseDto> {
-    this._log("createLike satrt");
+    this._log("create satrt");
 
     // targetId 존재하는지 확인
     const likeTarget = await this._getLikeTarget(type, targetId);
@@ -142,12 +142,12 @@ export class LikeService implements ILikeService {
     }
   }
 
-  public async deleteLike(
+  public async remove(
     type: string,
     targetId: number,
     user: User
   ): Promise<void> {
-    this._log("deleteLike satrt");
+    this._log("remove satrt");
 
     // targetId 존재하는지 확인
     const likeTarget = await this._getLikeTarget(type, targetId);

--- a/src/modules/post/interfaces/IPost.service.ts
+++ b/src/modules/post/interfaces/IPost.service.ts
@@ -25,7 +25,7 @@ export interface IPostService {
   increaseCommentCount(id: number): Promise<void>;
   increaseLikeCount(id: number): Promise<void>;
   decreaseLikeCount(id: number): Promise<void>;
-  delete(user: User, id: number): Promise<void>;
+  remove(user: User, id: number): Promise<void>;
   getDetail(user: User, id: number): Promise<PostResponseDto>;
   isValid(id: number): Promise<boolean>;
   getMyPosts(user: User, pageOptionsDto: GetMyPostsDto): Promise<any>; // TODO: 리턴타입, postService.getUserPosts로

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -71,7 +71,7 @@ export class PostController {
     const user = req.user as User;
     const { id } = param;
 
-    await this._postService.delete(user, id);
+    await this._postService.remove(user, id);
 
     return res.status(204).end();
   }

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -171,8 +171,8 @@ export class PostService implements IPostService {
     if (!hasDecreased) throw new NotFoundException(`not exists post`);
   }
 
-  public async delete(user: User, id: number): Promise<void> {
-    this._log(`delete start`);
+  public async remove(user: User, id: number): Promise<void> {
+    this._log(`remove start`);
     const post = await this._postRepository.findOneById(id);
 
     this._log(`check exists post id ${id}`);


### PR DESCRIPTION
## 개요
삭제 메소드이름이 `remove`, `delete`로 나뉘는 상황
## 작업사항
- `delete` -> `remove`로 수정

## 기타
https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/delete
- 자바스크립트는 delete 연산자 때문에 함수, 변수이름에 delete를 못쓰는데, 메소드에는 되네요..
  암튼 위와 같은 이유가 있어서 remove로 선택했어요
- like쪽은 `deleteLike`라서 일단 냅두었습니다. 코멘트 달아주셔서 통일할지 의견 부탁드려요!
- 다음은 리포지토리 `remove` 리턴을 void에서 boolean으로 수정할 예정입니다