### PR TITLE
Update: notification service 조회 next id 로직

### DIFF
--- a/src/modules/notifications/interfaces/INotification.service.ts
+++ b/src/modules/notifications/interfaces/INotification.service.ts
@@ -7,19 +7,35 @@ import {
 } from "../../../shared/page";
 
 export interface INotificationService {
+  /**
+   * targetUser에 의해 user에게 알림을 생성합니다.
+   * @param targetUser 알림을 준 user
+   * @param userId     알림 대상 user id
+   * @param targetId   알림 대상 id
+   * @param type       알림 종류
+   */
   createByTargetUser(
     targetUser: User,
     userId: number,
     targetId: number,
     type: NotificationType
   ): Promise<void>;
+  /**
+   * user의 알림을 모두 조회합니다.
+   */
   getAllByUser(
     user: User,
     pageOptionsDto: GetAllNotificationsDto
   ): Promise<
     PageResponseDto<PageInfiniteScrollInfoDto, NotificationResponseDto>
   >;
+  /**
+   * user의 알림 하나를 읽음 처리합니다.
+   */
   readOne(user: User, id: number): Promise<void>;
+  /**
+   * user의 알림 전체를 읽음 처리 후, 읽음 처리한 알림 수를 리턴합니다.
+   */
   readAll(user: User): Promise<number>;
   // countUnread():Promise<number>
 }

--- a/src/modules/notifications/interfaces/INotification.service.ts
+++ b/src/modules/notifications/interfaces/INotification.service.ts
@@ -13,7 +13,7 @@ export interface INotificationService {
     targetId: number,
     type: NotificationType
   ): Promise<void>;
-  findAll(
+  getAllByUser(
     user: User,
     pageOptionsDto: GetAllNotificationsDto
   ): Promise<

--- a/src/modules/notifications/notification.controller.ts
+++ b/src/modules/notifications/notification.controller.ts
@@ -60,7 +60,7 @@ export class NotificationController {
     res: Response
   ) {
     const user = req.user as User;
-    const data = await this._notificationService.findAll(user, query);
+    const data = await this._notificationService.getAllByUser(user, query);
     return res.status(200).json(data);
   }
 }

--- a/src/modules/notifications/notification.repository.ts
+++ b/src/modules/notifications/notification.repository.ts
@@ -35,7 +35,7 @@ export class NotificationtRepository implements INotificationRepository {
       .andWhere("notification.id >= :startId", {
         startId: pageOptionsDto.startId,
       })
-      .take(pageOptionsDto.maxResults + 1) // nextId를 위한 +1
+      .take(pageOptionsDto.maxResults)
       .orderBy(`notification.createdAt`, "ASC");
 
     if (pageOptionsDto.all)

--- a/src/modules/notifications/notification.service.ts
+++ b/src/modules/notifications/notification.service.ts
@@ -56,7 +56,10 @@ export class NotificationService implements INotificationService {
   }
 
   // user의 알림 리스트를 조회한다.
-  public async findAll(user: User, pageOptionsDto: GetAllNotificationsDto) {
+  public async getAllByUser(
+    user: User,
+    pageOptionsDto: GetAllNotificationsDto
+  ) {
     this._log(`findAll start`);
 
     const [notificationArray, totalCount] =

--- a/src/modules/notifications/notification.service.ts
+++ b/src/modules/notifications/notification.service.ts
@@ -29,7 +29,6 @@ export class NotificationService implements INotificationService {
     this._logger.trace(`[NotificationService] ${message}`);
   }
 
-  // targetUser에 의해 userId에게 알림을 생성한다.
   public async createByTargetUser(
     targetUser: User,
     userId: number,
@@ -37,32 +36,32 @@ export class NotificationService implements INotificationService {
     type: NotificationType
   ): Promise<void> {
     this._log(`createByTargetUser start`);
-    //return: 알림대상 user === 알림원인 user
+
+    this._log(`check if user and target user are the same user`);
     if (userId === targetUser.id) {
-      this._log(`createByTargetUser fail - same target user & user`);
+      this._log(`createByTargetUser fail - target user === user`);
       return;
     }
 
+    this._log(`check if target user is valid`);
     const isValidUser = await this._userService.isValid(userId);
-    //return: 없는 || 탈퇴 || 가입처리 안한 user
     if (!isValidUser) {
       this._log(`createByTargetUser fail - isValidUser`);
       return;
     }
 
+    this._log(`create notification successful`);
     const notification = Notification.of(targetUser, userId, targetId, type);
-    this._log(`create notification`);
     await this._notificationRepository.create(notification);
   }
 
-  // user의 알림 리스트를 조회한다.
   public async getAllByUser(
     user: User,
     pageOptionsDto: GetAllNotificationsDto
   ) {
     this._log(`findAll start`);
 
-    const [notificationArray, totalCount] =
+    const [notificationArray, totalCount] = //TODO: pageOptionsDto에 따라 count 달라지므로 수정필요
       await this._notificationRepository.findAllByUserId(
         user.id,
         pageOptionsDto
@@ -73,7 +72,6 @@ export class NotificationService implements INotificationService {
     if (notificationArray.length < pageOptionsDto.maxResults) nextId = null;
     else nextId = notificationArray[notificationArray.length - 1].id;
 
-    // 응답 DTO로 변환후 리턴
     const pageInfoDto = new PageInfiniteScrollInfoDto(
       notificationArray.length,
       nextId
@@ -87,23 +85,22 @@ export class NotificationService implements INotificationService {
 
   public async readOne(user: User, id: number): Promise<void> {
     this._log(`readOne start`);
-    this._log(`exsits notification ? ${id}`);
-    const notification = await this._notificationRepository.findOneById(id);
 
+    this._log(`check if notification id ${id} exists`);
+    const notification = await this._notificationRepository.findOneById(id);
     if (!notification) throw new NotFoundException("not exists notification");
-    this._log(`check authorization`);
+
+    this._log(`check if user has authorization for notification id ${id}`);
     if (notification.userId !== user.id)
       throw new ForbiddenException("authorization error");
 
-    // 이미 읽은 알림
-    this._log(`check already read`);
+    this._log(`check if a notification has already been read`);
     if (notification.readAt)
       throw new BadReqeustException("already read notification");
 
     await this._notificationRepository.update(id, { readAt: new Date() });
   }
 
-  // readAt 업데이트 후 읽은 알림 수를 리턴한다.
   public async readAll(user: User) {
     this._log(`readAll start`);
     return await this._notificationRepository.updateAllUnread(user.id);

--- a/src/modules/notifications/notification.service.ts
+++ b/src/modules/notifications/notification.service.ts
@@ -65,12 +65,10 @@ export class NotificationService implements INotificationService {
         pageOptionsDto
       );
 
-    // 다음 알림 페이지 있는지 확인
-    let nextId = null;
-    if (notificationArray.length === pageOptionsDto.maxResults + 1) {
-      nextId = notificationArray[notificationArray.length - 1].id;
-      notificationArray.pop();
-    }
+    // notificationArray 길이가 maxResults보다 작다면 nextId는 null, 아니라면 마지막 idx의 id 할당
+    let nextId: number | null;
+    if (notificationArray.length < pageOptionsDto.maxResults) nextId = null;
+    else nextId = notificationArray[notificationArray.length - 1].id;
 
     // 응답 DTO로 변환후 리턴
     const pageInfoDto = new PageInfiniteScrollInfoDto(


### PR DESCRIPTION
## 개요
notification  service `find all` 메서드의 next id 로직 수정이 필요한 상황
## 작업사항
- next id 로직 수정
- `findAll` -> `getAllByUser`로 수정
- notification  service 주석, 로그 개선
## 변경로직
### 변경전
```ts
    // 다음 알림 페이지 있는지 확인
    let nextId = null;
    if (notificationArray.length === pageOptionsDto.maxResults + 1) {
      nextId = notificationArray[notificationArray.length - 1].id;
      notificationArray.pop();
    }
```
레포지토리
```ts
.take(pageOptionsDto.maxResults + 1) // nextId를 위한 +1
```
### 변경후
```ts
    // notificationArray 길이가 maxResults보다 작다면 nextId는 null, 아니라면 마지막 idx의 id 할당
    let nextId: number | null;
    if (notificationArray.length < pageOptionsDto.maxResults) nextId = null;
    else nextId = notificationArray[notificationArray.length - 1].id;
```
레포지토리
```ts
.take(pageOptionsDto.maxResults)
```

## 기타
- 예외처리에 조건문에 대해 추적하려고 log를 추가하다보니 주석이랑 겹치는 것 같아서
겹치는 부분에 대해서는 log를 우선시 했습니당