### PR TITLE
Fix: user 알림 조회 API

### DIFF
--- a/src/modules/notifications/dto/index.ts
+++ b/src/modules/notifications/dto/index.ts
@@ -1,3 +1,4 @@
 export { ReadOneDto } from "./read-one.dto";
 export { GetAllNotificationsDto } from "./get-all-notifications.dto";
 export { NotificationResponseDto } from "./notification-response.dto";
+export { NotificationPageResponseDto } from "./notification-page-response.dto";

--- a/src/modules/notifications/dto/notification-page-response.dto.ts
+++ b/src/modules/notifications/dto/notification-page-response.dto.ts
@@ -1,0 +1,12 @@
+import { PageResponseDto } from "../../../shared/page";
+
+export class NotificationPageResponseDto<Page, Item> extends PageResponseDto<
+  Page,
+  Item
+> {
+  totalUnreadCount: number;
+  constructor(totalUnreadCount: number, pageInfo: Page, items: Item[]) {
+    super(pageInfo, items);
+    this.totalUnreadCount = totalUnreadCount;
+  }
+}

--- a/src/modules/notifications/interfaces/INotification.repository.ts
+++ b/src/modules/notifications/interfaces/INotification.repository.ts
@@ -6,7 +6,7 @@ export interface INotificationRepository {
   findAllByUserId(
     userId: number,
     pageOptionsDto: GetAllNotificationsDto
-  ): Promise<[Notification[], number]>;
+  ): Promise<Notification[]>;
   findOneById(id: number): Promise<Notification>;
   update(id: number, payload: Partial<Notification>): Promise<Notification>;
   updateAllUnread(userId: number): Promise<number>;

--- a/src/modules/notifications/interfaces/INotification.repository.ts
+++ b/src/modules/notifications/interfaces/INotification.repository.ts
@@ -10,5 +10,5 @@ export interface INotificationRepository {
   findOneById(id: number): Promise<Notification>;
   update(id: number, payload: Partial<Notification>): Promise<Notification>;
   updateAllUnread(userId: number): Promise<number>;
-  //countUnreadByUserId(userId:number): Promise<number>;
+  countUnreadByUserId(userId: number): Promise<number>;
 }

--- a/src/modules/notifications/notification.repository.ts
+++ b/src/modules/notifications/notification.repository.ts
@@ -58,4 +58,9 @@ export class NotificationtRepository implements INotificationRepository {
     } as QueryDeepPartialEntity<Notification>);
     return affected!; // update된 컬럼수
   }
+
+  public async countUnreadByUserId(userId: number): Promise<number> {
+    const repository = await this._database.getRepository(Notification);
+    return await repository.countBy({ userId, readAt: IsNull() });
+  }
 }

--- a/src/modules/notifications/notification.repository.ts
+++ b/src/modules/notifications/notification.repository.ts
@@ -27,7 +27,7 @@ export class NotificationtRepository implements INotificationRepository {
   public async findAllByUserId(
     userId: number,
     pageOptionsDto: GetAllNotificationsDto
-  ): Promise<[Notification[], number]> {
+  ): Promise<Notification[]> {
     const repository = await this._database.getRepository(Notification);
     const queryBuilder = repository
       .createQueryBuilder("notification")
@@ -41,7 +41,7 @@ export class NotificationtRepository implements INotificationRepository {
     if (pageOptionsDto.all)
       queryBuilder.andWhere("notification.readAt IS NULL");
 
-    return queryBuilder.getManyAndCount();
+    return queryBuilder.getMany();
   }
 
   public async update(id: number, payload: Partial<Notification>) {

--- a/src/modules/notifications/notification.service.ts
+++ b/src/modules/notifications/notification.service.ts
@@ -61,7 +61,7 @@ export class NotificationService implements INotificationService {
   ) {
     this._log(`findAll start`);
 
-    const [notificationArray, totalCount] = //TODO: pageOptionsDto에 따라 count 달라지므로 수정필요
+    const notificationArray = //TODO: pageOptionsDto에 따라 count 달라지므로 수정필요
       await this._notificationRepository.findAllByUserId(
         user.id,
         pageOptionsDto

--- a/src/modules/notifications/notification.service.ts
+++ b/src/modules/notifications/notification.service.ts
@@ -12,7 +12,11 @@ import {
   ForbiddenException,
   NotFoundException,
 } from "../../shared/errors/all.exception";
-import { GetAllNotificationsDto, NotificationResponseDto } from "./dto";
+import {
+  GetAllNotificationsDto,
+  NotificationPageResponseDto,
+  NotificationResponseDto,
+} from "./dto";
 import { PageInfiniteScrollInfoDto, PageResponseDto } from "../../shared/page";
 
 @injectable()
@@ -59,9 +63,25 @@ export class NotificationService implements INotificationService {
     user: User,
     pageOptionsDto: GetAllNotificationsDto
   ) {
-    this._log(`findAll start`);
+    this._log(`getAllByUser start`);
 
-    const notificationArray = //TODO: pageOptionsDto에 따라 count 달라지므로 수정필요
+    const totalUnreadCount =
+      await this._notificationRepository.countUnreadByUserId(user.id);
+
+    // totalUnreadCount가 0이면 조회하지않고 바로 응답
+    if (totalUnreadCount === 0) {
+      this._log(`totalUnreadCountt is 0, so return immediately`);
+      return new NotificationPageResponseDto(
+        totalUnreadCount,
+        {
+          itemsPerPage: 0,
+          nextId: null,
+        },
+        []
+      );
+    }
+
+    const notificationArray =
       await this._notificationRepository.findAllByUserId(
         user.id,
         pageOptionsDto
@@ -77,7 +97,8 @@ export class NotificationService implements INotificationService {
       nextId
     );
 
-    return new PageResponseDto(
+    return new NotificationPageResponseDto(
+      totalUnreadCount,
       pageInfoDto,
       notificationArray.map((e) => new NotificationResponseDto(e))
     );

--- a/src/swagger/responses/notifications/index.get.yaml
+++ b/src/swagger/responses/notifications/index.get.yaml
@@ -5,12 +5,12 @@
       schema:
         type: object
         properties:
+          totalUnreadCount:
+            type: integer
+            exmaple: 30
           pageInfo:
             type: object
             properties:
-              totalCounts:
-                type: integer
-                example: 20
               itemsPerPage:
                 type: integer
                 example: 30


### PR DESCRIPTION
## 개요
- 알림 조회 API는 no offset 방식이라서 다음 페이지 요청마다 안읽은 알림수`totalCount`가 바뀌는 상황
## 작업사항
- `PageResponseDto` 상속하여 `totalUnreadCount` 필드를 추가한 `NotificationPageResponseDto` 추가
- notification repository에 `countUnreadByUserId` 추가
- swagger 수정
## 변경로직

### 변경전
리턴
```ts
return new PageResponseDto(
      pageInfoDto,
      notificationArray.map((e) => new NotificationResponseDto(e))
    );
```
### 변경후
- `totalUnreadCount` 필드를 추가한 `NotificationPageResponseDto`로 리턴
```ts
  return new NotificationPageResponseDto(
      totalUnreadCount,
      pageInfoDto,
      notificationArray.map((e) => new NotificationResponseDto(e))
    );
```
- 알림 정보 조회전, user의 안읽은 알림수가 0이라면 바로 return
```ts
const totalUnreadCount =
      await this._notificationRepository.countUnreadByUserId(user.id);

    // totalUnreadCount가 0이면 조회하지않고 바로 응답
    if (totalUnreadCount === 0) {
      this._log(`totalUnreadCountt is 0, so return immediately`);
      return new NotificationPageResponseDto(
        totalUnreadCount,
        {
          itemsPerPage: 0,
          nextId: null,
        },
        []
      );
    }

const notificationArray =
      await this._notificationRepository.findAllByUserId(...생략
```
## 기타
