### PR TITLE
Fix: CheckLoginStatus 미들웨어 요청 인증 헤더에서 null일 경우 추가

### DIFF
--- a/src/middlewares/check-login-status.middleware.ts
+++ b/src/middlewares/check-login-status.middleware.ts
@@ -35,8 +35,9 @@ export class CheckLoginStatus extends BaseMiddleware {
       if (header && header.startsWith(AUTH_TYPE))
         accessToken = header.split(" ")[1];
 
-      // accessToken이 없다면 미로그인 상태. next 호출
-      if (!accessToken) {
+      // accessToken이 없거나 "null"이라면 미로그인 상태이므로 next를 호출한다.
+      // 프론트에서 로그인 안해도 인증 헤더가 넘어옵니다 (Authorization : Bearer null)
+      if (!accessToken || accessToken === "null") {
         this._log(`not logged in. call next`);
         return next();
       }


### PR DESCRIPTION
## 개요
* 클라이언트 측에서 미로그인여도 Authorization : Bearer null 헤더로 항상 넘어오는 상태
```ts
    detail = async (accessToken, id) => {
        try {
            const res = await this.board.get(`posts/${id}`, {
                headers: {
                    Authorization: `Bearer ${accessToken}`,
                },
            });
            return res;
        } catch (e) {
            console.log(e);
        }
    };
```
## 작업사항
- `CheckLoginStatus` 미들웨어에서 `Authorization: Bearer null`인 상황 체크
## 변경로직

### 변경전
```ts
      // accessToken이 없다면 미로그인 상태. next 호출
      if (!accessToken) {
        this._log(`not logged in. call next`);
        return next();
      }
```
### 변경후
```ts
      // accessToken이 없거나 "null"이라면 미로그인 상태이므로 next를 호출한다.
      // 프론트에서 로그인 안해도 인증 헤더가 넘어옵니다 (Authorization : Bearer null)
      if (!accessToken || accessToken === "null") {
        this._log(`not logged in. call next`);
        return next();
      }
```