### PR TITLE
Update: user repo update 수정후 user service에 적용

### DIFF
--- a/src/modules/user/interfaces/IUser.repository.ts
+++ b/src/modules/user/interfaces/IUser.repository.ts
@@ -14,5 +14,5 @@ export interface IUserRepository {
     providerId: string
   ): Promise<User[]>;
   findOneStatus(id: number): Promise<User | null>;
-  update(id: number, payload: Partial<User>): Promise<User>;
+  update(id: number, payload: Partial<User>): Promise<boolean>;
 }

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -52,11 +52,13 @@ export class UserRepository implements IUserRepository {
     });
   }
 
-  public async update(id: number, payload: Partial<User>): Promise<User> {
+  public async update(id: number, payload: Partial<User>): Promise<boolean> {
     const repository = await this._database.getRepository(User);
-    const updatedUser = await repository
-      .update(id, payload as QueryDeepPartialEntity<User>)
-      .then(async () => await repository.findOne({ where: { id } }));
-    return updatedUser;
+    const result = await repository.update(
+      id,
+      payload as QueryDeepPartialEntity<User>
+    );
+    if (result.affected == 1) return true;
+    return false;
   }
 }


### PR DESCRIPTION
## 개요
- repo update 코드들이 통일되어있지 않는 상황
- update 쿼리 이후 findOne 쿼리를 더 수행하는 상황
## 작업사항
- user repo update 이후 findOne제거. update 성공 유무를 return
- user service쪽 user update의 리턴이 boolean으로 바뀌었음으로 로직 수정
## 변경로직
### 변경전
- 기존엔 update에 findOneById가 포함되어 user 엔티티를 리턴했음
```ts
const updatedUser = await userRepository.updqte(...);
```
### 변경후
- boolean hasUpdated 값에따라 NotFoundException 처리
```ts
    this._log(`check if the update request was successful`);
    const hasUpdated = await this._userRepository.update(...);
    if (!hasUpdated) throw new NotFoundException("not exists user");
```
- 이후 access token 재발급이 필요할때 기존 user에 재할당함
```ts
user.mbti = mbti;
```
## 기타
`이후 access token 재발급이 필요할때 기존 user에 재할당함`
- 엔티티에 직접 할당이 일어나는게 괜찮은지..
- 아니면 update이후 service에서 repo.findOneby를 다시 요청하는지..
- 아니면 close후 기존을 유지하여 repo.update에 findOneById로 통일하든지
어떤 방향으로 갈지 궁금합니다