### PR TITLE
Update: 게시글 상세조회 

### DIFF
--- a/src/modules/post/dto/index.ts
+++ b/src/modules/post/dto/index.ts
@@ -1,6 +1,6 @@
 export { CreatePostDto } from "./create-post.dto";
 export { GetAllPostDto } from "./get-all-post.dto";
-export { PostResponseDto } from "./post-response.dto";
+export { PostResponseDto } from "./response/post-response.dto";
 export { SearchPostDto } from "./search-post.dto";
 export { GetMyPostsDto } from "./get-my-posts.dto";
 export { UpdatePostDto } from "./update-post.dto";

--- a/src/modules/post/dto/index.ts
+++ b/src/modules/post/dto/index.ts
@@ -1,6 +1,7 @@
 export { CreatePostDto } from "./create-post.dto";
 export { GetAllPostDto } from "./get-all-post.dto";
 export { PostResponseDto } from "./response/post-response.dto";
+export { PostDetailResponseDto } from "./response/post-detail-response.dto";
 export { SearchPostDto } from "./search-post.dto";
 export { GetMyPostsDto } from "./get-my-posts.dto";
 export { UpdatePostDto } from "./update-post.dto";

--- a/src/modules/post/dto/response/post-detail-response.dto.ts
+++ b/src/modules/post/dto/response/post-detail-response.dto.ts
@@ -1,0 +1,18 @@
+import { User } from "../../../user/entity/user.entity";
+import { Post } from "../../entity/post.entity";
+import { PostResponseDto } from "./post-response.dto";
+
+export class PostDetailResponseDto extends PostResponseDto {
+  isUserLike: boolean;
+  isUserBookmark: boolean;
+  constructor(
+    post: Post,
+    user: User,
+    isUserLike: boolean,
+    isUserBookmark: boolean
+  ) {
+    super(post, user);
+    this.isUserLike = isUserLike;
+    this.isUserBookmark = isUserBookmark;
+  }
+}

--- a/src/modules/post/dto/response/post-response.dto.ts
+++ b/src/modules/post/dto/response/post-response.dto.ts
@@ -1,6 +1,6 @@
-import { PostType } from "../../../shared/enum.shared";
-import { User } from "../../user/entity/user.entity";
-import { Post } from "../entity/post.entity";
+import { PostType } from "../../../../shared/enum.shared";
+import { User } from "../../../user/entity/user.entity";
+import { Post } from "../../entity/post.entity";
 
 export class PostResponseDto {
   id: number;

--- a/src/modules/post/interfaces/IPost.service.ts
+++ b/src/modules/post/interfaces/IPost.service.ts
@@ -10,6 +10,7 @@ import {
   GetAllPostDto,
   GetTrendDto,
   SearchPostDto,
+  PostDetailResponseDto,
 } from "../dto";
 
 export interface IPostService {
@@ -26,7 +27,7 @@ export interface IPostService {
   increaseLikeCount(id: number): Promise<void>;
   decreaseLikeCount(id: number): Promise<void>;
   remove(user: User, id: number): Promise<void>;
-  getDetail(user: User, id: number): Promise<PostResponseDto>;
+  getDetail(user: User, id: number): Promise<PostDetailResponseDto>;
   isValid(id: number): Promise<boolean>;
   getMyPosts(user: User, pageOptionsDto: GetMyPostsDto): Promise<any>; // TODO: 리턴타입, postService.getUserPosts로
   getTrends(

--- a/src/swagger/responses/posts/id.get.yaml
+++ b/src/swagger/responses/posts/id.get.yaml
@@ -56,6 +56,12 @@
           updatedAt:
             type: Date | null
             example: null
+          isUserLike:
+            type: boolean
+            example: false
+          isUserBookmark:
+            type: boolean
+            example: false
 
 "403":
   description: mbti 카테고리 게시글의 mbti와 user 의 mbti와 다른 경우


### PR DESCRIPTION
## 개요
프론트 부분에서 게시글을 상세조회 할 때 유저가 게시글을 좋아요 했는지, 북마크 했는지 여부를 요구해서 수정

## 작업사항
기존에 `PostResponseDto` 로 반환하던걸 `PostDetailResponseDto` 를 새로 만들어 반환함
이 과정에서 dto에 response 폴더를 생성하여 dto 요청과 응답을 분리
swagger 수정

## 변경로직

### 변경후
<img width="537" alt="스크린샷 2022-09-10 오전 2 10 22" src="https://user-images.githubusercontent.com/37575974/189406422-d8e7e956-5b3b-421b-b0c9-d01d670c1301.png">

## 기타
- 이런식으로 쿼리를 또 날리면서 게시글 좋아요나 북마크 여부를 가져오는게 맞는지 모르겠다.
- 다시 보니까 like 부분은 리펙토링이 꽤 많이 필요해 보이네.. 추후에 수정 필수!!
