### PR TITLE
Fix: 마이그레이션 실행 조건문 추가

### DIFF
--- a/src/migrations/1660664316256-create-upate-log-table.ts
+++ b/src/migrations/1660664316256-create-upate-log-table.ts
@@ -2,12 +2,16 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class createUpateLogTable1660664316256 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      "CREATE TABLE `update_log` (`id` int UNSIGNED NOT NULL AUTO_INCREMENT, `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), `type` varchar(20) NOT NULL COMMENT '업데이트 종류', `before` varchar(10) NOT NULL COMMENT '업데이트 전', `after` varchar(10) NOT NULL COMMENT '업데이트 후', `user_id` int UNSIGNED NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB"
-    );
-    await queryRunner.query(
-      "ALTER TABLE `update_log` ADD CONSTRAINT `FK_efe915ac8b3f0f867627fc75429` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION"
-    );
+    const hasTable = await queryRunner.hasTable("update_log");
+
+    if (!hasTable) {
+      await queryRunner.query(
+        "CREATE TABLE `update_log` (`id` int UNSIGNED NOT NULL AUTO_INCREMENT, `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), `type` varchar(20) NOT NULL COMMENT '업데이트 종류', `before` varchar(10) NOT NULL COMMENT '업데이트 전', `after` varchar(10) NOT NULL COMMENT '업데이트 후', `user_id` int UNSIGNED NOT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB"
+      );
+      await queryRunner.query(
+        "ALTER TABLE `update_log` ADD CONSTRAINT `FK_efe915ac8b3f0f867627fc75429` FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON DELETE CASCADE ON UPDATE NO ACTION"
+      );
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {}

--- a/src/migrations/1660907288956-migrations.ts
+++ b/src/migrations/1660907288956-migrations.ts
@@ -1,16 +1,23 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class migrations1660907288956 implements MigrationInterface {
-    name = 'migrations1660907288956'
+  name = "migrations1660907288956";
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE \`file\` (\`id\` int UNSIGNED NOT NULL AUTO_INCREMENT, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`url\` text NOT NULL COMMENT 's3에 담겨 있는 파일 url', \`extension\` varchar(255) NOT NULL COMMENT '파일 확장자', \`is_active\` tinyint NOT NULL COMMENT '파일 활성 여부' DEFAULT 1, \`target_id\` int UNSIGNED NOT NULL COMMENT '파일이 업로드 된 타켓 id', \`target_type\` tinyint NOT NULL COMMENT '파일이 업로드 될 타겟 종류 [1: user, 2: post, 3: comment]', PRIMARY KEY (\`id\`)) ENGINE=InnoDB`);
-        await queryRunner.query(`ALTER TABLE \`post\` ADD \`thumbnail\` text NULL COMMENT '썸네일 이미지 url'`);
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const hasTable = await queryRunner.hasTable("file");
+
+    if (!hasTable) {
+      await queryRunner.query(
+        `CREATE TABLE \`file\` (\`id\` int UNSIGNED NOT NULL AUTO_INCREMENT, \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), \`url\` text NOT NULL COMMENT 's3에 담겨 있는 파일 url', \`extension\` varchar(255) NOT NULL COMMENT '파일 확장자', \`is_active\` tinyint NOT NULL COMMENT '파일 활성 여부' DEFAULT 1, \`target_id\` int UNSIGNED NOT NULL COMMENT '파일이 업로드 된 타켓 id', \`target_type\` tinyint NOT NULL COMMENT '파일이 업로드 될 타겟 종류 [1: user, 2: post, 3: comment]', PRIMARY KEY (\`id\`)) ENGINE=InnoDB`
+      );
+      await queryRunner.query(
+        `ALTER TABLE \`post\` ADD \`thumbnail\` text NULL COMMENT '썸네일 이미지 url'`
+      );
     }
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`ALTER TABLE \`post\` DROP COLUMN \`thumbnail\``);
-        await queryRunner.query(`DROP TABLE \`file\``);
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`post\` DROP COLUMN \`thumbnail\``);
+    await queryRunner.query(`DROP TABLE \`file\``);
+  }
 }


### PR DESCRIPTION
## 개요

DB 테이블 정보가 entity와 동일할 때, 마이그레이션 실행시 충돌 에러 일어나는 상황

## 작업사항
다음 코드 추가하여 테이블이 없어야 테이블 생성일어나게 수정
```ts
const hasTable = await queryRunner.hasTable("file");

if(!hasTable) {
  ...
}
```
